### PR TITLE
group admin settings : tab property bound to value instead of v-model

### DIFF
--- a/packages/ui/routes/groups/_groupId/index.vue
+++ b/packages/ui/routes/groups/_groupId/index.vue
@@ -103,7 +103,7 @@ export default {
     <template #menu>
       <bs-group-menu />
     </template>
-    <v-tabs v-model="tab" centered>
+    <v-tabs :value="tab" centered>
       <v-tabs-slider color="accent" />
       <v-tab href="#group-informations">
         {{ $t('groups.tabs.informations') }}


### PR DESCRIPTION
https://stackoverflow.com/questions/46106037/vuex-computed-property-name-was-assigned-to-but-it-has-no-setter

![image](https://user-images.githubusercontent.com/73607425/110652528-bc6c9700-81bc-11eb-9301-59cf4b06da73.png)


