### PR TITLE
Fix: full width for left menu

### DIFF
--- a/packages/ui/components/layout-left-menu.vue
+++ b/packages/ui/components/layout-left-menu.vue
@@ -22,6 +22,9 @@ export default {
 </template>
 
 <style scoped>
+.v-navigation-drawer {
+  width: 100% !important;
+}
 .navigation-drawer-container {
   max-height: calc(100vh - 4rem);
 }


### PR DESCRIPTION
The spacing problem came from the fact that the menu on the left did not take the full width available. We added the `width: 100%` to the menu to fix the issue.

Before:
![image](https://user-images.githubusercontent.com/80386314/111660356-48f70500-880e-11eb-88f3-2f52ff8c6a72.png)

After:
![image](https://user-images.githubusercontent.com/80386314/111659815-cec68080-880d-11eb-8f4a-5af0471d361d.png)

