### PR TITLE
Fix: Wording

### DIFF
--- a/packages/ui/helpers/locales/en.js
+++ b/packages/ui/helpers/locales/en.js
@@ -27,6 +27,7 @@ export default {
         },
       },
     },
+    add: 'Add',
     teams: 'Workspaces',
     addTags: 'Add tags',
     copyMail: 'Copy',

--- a/packages/ui/helpers/locales/fr.js
+++ b/packages/ui/helpers/locales/fr.js
@@ -27,6 +27,7 @@ export default {
         },
       },
     },
+    add: 'Ajouter',
     addTags: 'Ajouter des labels',
     copyMail: 'Copier',
     copyMailAction: 'Créer une copie',
@@ -180,7 +181,7 @@ export default {
     duplicate: 'Dupliquer l\'email',
     duplicateNotice:
       'Êtes-vous sûr de vouloir dupliquer <strong>{name}</strong> ?',
-    name: 'Nommer l\'email',
+    name: 'Nom de l\'email',
     rename: 'Renommer l\'email',
     selectedCount: '{count} email sélectionné | {count} emails sélectionnés',
     selectedShortCount: '{count} email | {count} emails',

--- a/packages/ui/routes/mailings/__partials/modal-new-mail.vue
+++ b/packages/ui/routes/mailings/__partials/modal-new-mail.vue
@@ -130,7 +130,7 @@ export default {
           {{ $t('global.cancel') }}
         </v-btn>
         <v-btn :disabled="!isValidToCreate" type="submit" color="primary">
-          {{ $t('global.newMailing') }}
+          {{ $t('global.add') }}
         </v-btn>
       </v-card-actions>
     </v-form>


### PR DESCRIPTION
Wording corrected :

We now have "Nom de l'email" and "Ajouter"
In English, the confirm button was also changed to "Add"

![image](https://user-images.githubusercontent.com/80386314/112502282-3d658a00-8d8a-11eb-9cd6-b85695630208.png)
