### PR TITLE
Fix tab header style bug

### DIFF
--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -49,7 +49,7 @@
       </div>
     <!-- /ko -->
   </div>
-</div>
+<//div>div>
 
 <div id="toolimages" class="slidebar" data-bind="scrollable: true, css: { hidden: $root.showGallery() === false }">
   <div class="close" data-bind="click: $root.showGallery.bind($element, false);">X</div>


### PR DESCRIPTION
Fixe tabs header bug in the editor gallery image section.
![image](https://user-images.githubusercontent.com/57661415/126997951-e8f17e9a-a544-4e7b-8763-57621a554e64.png)
 