### PR TITLE
Delete adobe encoding section

### DIFF
--- a/packages/server/utils/process-mosaico-html-render.js
+++ b/packages/server/utils/process-mosaico-html-render.js
@@ -40,7 +40,6 @@ function secureHtml(html) {
 const selligentTagRegexp = /~([^~]+)~/g;
 const np6TagRegexp = /{{([^~]+)}}/g;
 const actitoTagRegexp = /\${(.+?)\}/g;
-const adobeTagRegexp = /<%(.+?)%>/g;
 
 const decodeTag = (match, tag) => {
   let decodedTag = htmlEntities.decode(tag);
@@ -74,20 +73,13 @@ function decodeActitoTags(html) {
   return html;
 }
 
-function decodeAdobeTags(html) {
-  return html.replace(
-    adobeTagRegexp,
-    (match, tag) => `<%${decodeTag(match, tag)}%>`
-  );
-}
 const basicHtmlProcessing = _.flow(
   removeTinyMceExtraBrTag,
   replaceTabs,
   secureHtml,
   decodeSelligentTags,
   decodeNp6Tags,
-  decodeActitoTags,
-  decodeAdobeTags
+  decodeActitoTags
 );
 
 module.exports = basicHtmlProcessing;


### PR DESCRIPTION
Fix: 
```
<%= '<img src="' + targetData.productInfo1.imagePath + '" border="0" width="180" style="display: block; margin: 0px auto;" alt="' + targetData.productInfo1.productName + '"/>' %>
```
Produces on local download 
```
<%= '<img src="'   targetData.productInfo1.imagePath   '" style="display: block; margin: 0px auto;" alt="'   targetData.productInfo1.productName   '" width="180" border="0"/>' %>
```