### PR TITLE
Update color for labels of disabled input

### DIFF
--- a/packages/editor/src/css/badsender-editor.less
+++ b/packages/editor/src/css/badsender-editor.less
@@ -540,4 +540,8 @@ body {
     color: #333 !important;
     font-weight: 400 !important;
   }
+
+  input:disabled+label {
+    color: rgba(0, 0, 0, 0.42) !important;
+  }
 }


### PR DESCRIPTION
## Description

The goal of this PR is to fix the contrast problem (color of text) for labels when there is a disabled input.

## Result

![image](https://user-images.githubusercontent.com/55535169/199062281-7f4d6f01-9ebb-4bb9-bbc4-04326cf3ec1e.png)
