### PR TITLE
Gestion des variable personnalisées front end 

### DIFF
--- a/packages/ui/components/group/group-personalized-variable-tab.vue
+++ b/packages/ui/components/group/group-personalized-variable-tab.vue
@@ -74,7 +74,7 @@ export default {
         label: '',
         variable: '',
         status: 'new',
-        _id: '',
+        _id: undefined,
         deleting: false,
       });
     },
@@ -140,20 +140,23 @@ export default {
 
 <template>
   <div class="bs-group-personalized-variable-tab">
-    {{ console().log($v.variables.$each) }}
+    {{ console().log(variables) }}
     <v-data-table
       :headers="tableHeaders"
       :items="variables"
       :loading="loading"
       :hide-default-footer="true"
+      class="custom_table_class"
     >
       <template #item.status="{ item }">
-        <v-icon v-if="item.status === 'new'" small>
-          mdi-alert-outline
-        </v-icon>
-        <v-icon v-else-if="item.status === 'modified'" small>
-          mdi-pencil-outline
-        </v-icon>
+        <div>
+          <v-icon v-if="item.status === 'new'" small>
+            mdi-alert-outline
+          </v-icon>
+          <v-icon v-else-if="item.status === 'modified'" small>
+            mdi-pencil-outline
+          </v-icon>
+        </div>
       </template>
       <template #item.label="{ item, index }">
         <v-text-field
@@ -197,3 +200,15 @@ export default {
     </v-alert>
   </div>
 </template>
+
+<style>
+.custom_table_class tbody tr td {
+  border: none !important;
+}
+.custom_table_class thead th:first-child {
+  border-radius: 6px 0 0 0;
+}
+.custom_table_class thead th:lsat-child {
+  border-radius: 0 6px 0 0;
+}
+</style>

--- a/packages/ui/components/group/group-personalized-variable-tab.vue
+++ b/packages/ui/components/group/group-personalized-variable-tab.vue
@@ -1,0 +1,199 @@
+<script>
+import { required } from 'vuelidate/lib/validators';
+import axios from 'axios';
+
+export default {
+  name: 'GroupPersonalizedVariableTab',
+  data() {
+    return {
+      variables: [],
+      loading: false,
+      error: null,
+    };
+  },
+  validations: {
+    variables: {
+      $each: {
+        label: { required },
+        variable: { required },
+      },
+    },
+  },
+  computed: {
+    groupId() {
+      return this.$route.params.groupId;
+    },
+    tableHeaders() {
+      return [
+        {
+          align: 'left',
+          value: 'status',
+          sortable: false,
+        },
+        {
+          text: this.$t('variables.label'),
+          align: 'left',
+          value: 'label',
+          sortable: false,
+        },
+        {
+          text: this.$t('variables.variable'),
+          align: 'left',
+          value: 'variable',
+          sortable: false,
+        },
+        { text: '', value: 'actions', sortable: false, align: 'center' },
+      ];
+    },
+  },
+  created() {
+    this.getVariables();
+  },
+  methods: {
+    async getVariables() {
+      console.log(this.variables, 'first');
+      this.loading = true;
+      try {
+        const response = await axios.get(
+          `/api/groups/${this.groupId}/personalized-variables`
+        );
+        this.variables = response.data.items.map((item) => ({
+          ...item,
+          status: 'saved',
+          deleting: false,
+        }));
+        this.error = null;
+      } catch (error) {
+        this.error = error;
+      } finally {
+        this.loading = false;
+      }
+    },
+    addRow() {
+      this.variables.push({
+        label: '',
+        variable: '',
+        status: 'new',
+        _id: '',
+        deleting: false,
+      });
+    },
+    console() {
+      return console;
+    },
+    async submit() {
+      this.$v.$touch();
+      if (!this.$v.$invalid) {
+        this.loading = true;
+        try {
+          console.log(this.variables);
+          const variablesToSubmit = this.variables
+            .filter((variable) => variable.status !== 'saved')
+            .map(({ label, variable, _id, status }) => ({
+              label,
+              variable,
+              _id: status === 'modified' ? _id : undefined,
+            }));
+          await axios.post(
+            `/api/groups/${this.groupId}/personalized-variables`,
+            { personalizedVariables: variablesToSubmit }
+          );
+          this.variables = this.variables.map((item) => ({
+            ...item,
+            status: 'saved',
+            deleting: false,
+          }));
+          this.error = null;
+        } catch (error) {
+          this.error = error;
+        } finally {
+          this.loading = false;
+        }
+      }
+    },
+    async deleteVariable(index) {
+      console.log(this.variables[index]);
+      this.variables[index].deleting = true;
+      try {
+        const variable = this.variables[index];
+        if (variable.id) {
+          await axios.delete(
+            `/api/groups/${this.groupId}/personalized-variables/${variable.id}`
+          );
+        }
+        this.variables.splice(index, 1);
+        this.error = null;
+      } catch (error) {
+        this.error = error;
+      }
+    },
+    updateVariable(index, key, value) {
+      this.variables[index][key] = value;
+      if (this.variables[index].status === 'saved') {
+        this.variables[index].status = 'modified';
+      }
+      this.$v.variables.$each[index].$touch();
+    },
+  },
+};
+</script>
+
+<template>
+  <div class="bs-group-personalized-variable-tab">
+    {{ console().log($v.variables.$each) }}
+    <v-data-table
+      :headers="tableHeaders"
+      :items="variables"
+      :loading="loading"
+      :hide-default-footer="true"
+    >
+      <template #item.status="{ item }">
+        <v-icon v-if="item.status === 'new'" small>
+          mdi-alert-outline
+        </v-icon>
+        <v-icon v-else-if="item.status === 'modified'" small>
+          mdi-pencil-outline
+        </v-icon>
+      </template>
+      <template #item.label="{ item, index }">
+        <v-text-field
+          v-model="item.label"
+          :error-messages="
+            $v.variables.$each[index].label.$error
+              ? [$t('validation.required')]
+              : []
+          "
+          @input="updateVariable(index, 'label', $event)"
+          @blur="$v.variables.$each[index].label.$touch()"
+        />
+      </template>
+      <template #item.variable="{ item, index }">
+        <v-text-field
+          v-model="item.variable"
+          :error-messages="
+            $v.variables.$each[index].variable.$error
+              ? [$t('validation.required')]
+              : []
+          "
+          @input="updateVariable(index, 'variable', $event)"
+          @blur="$v.variables.$each[index].variable.$touch()"
+        />
+      </template>
+      <template #item.actions="{ index }">
+        <v-progress-circular v-if="variables[index].deleting" indeterminate />
+        <v-btn v-else icon @click="deleteVariable(index)">
+          <v-icon>mdi-delete</v-icon>
+        </v-btn>
+      </template>
+    </v-data-table>
+    <v-btn @click="addRow">
+      {{ $t('variables.addRow') }}
+    </v-btn>
+    <v-btn @click="submit">
+      {{ $t('variables.submit') }}
+    </v-btn>
+    <v-alert v-if="error" type="error">
+      {{ error.message }}
+    </v-alert>
+  </div>
+</template>

--- a/packages/ui/components/group/group-personalized-variable-tab.vue
+++ b/packages/ui/components/group/group-personalized-variable-tab.vue
@@ -151,11 +151,7 @@ export default {
           await this.$axios.post(postPersonalizedVariables(this.groupId), {
             personalizedVariables: variablesToSubmit,
           });
-          this.variables = this.variables.map((item) => ({
-            ...item,
-            status: 'saved',
-            deleting: false,
-          }));
+          this.getVariables();
           this.error = null;
           this.showSnackbar({
             text: this.$t('personalizedVariables.snackbars.updated'),
@@ -177,7 +173,7 @@ export default {
       if (this.variables[index].status === 'saved') {
         this.variables[index].status = 'modified';
       }
-      this.$v.variables.$each[index].$touch();
+      this.$v.variables.$each[index][key].$touch();
     },
     validationErrors(index, key) {
       const errors = [];

--- a/packages/ui/helpers/api-routes.js
+++ b/packages/ui/helpers/api-routes.js
@@ -238,3 +238,19 @@ export function getEmailsGroups() {
 export function getEmailsGroup(emailsGroupId) {
   return `/emails-groups/${emailsGroupId}`;
 }
+
+/// ///
+// Personalized Variables
+/// ///
+
+export function getPersonalizedVariables(groupId) {
+  return `/groups/${groupId}/personalized-variables`;
+}
+
+export function deletePersonalizedVariable(groupId, variableId) {
+  return `/groups/${groupId}/personalized-variables/${variableId}`;
+}
+
+export function postPersonalizedVariables(groupId) {
+  return `/groups/${groupId}/personalized-variables`;
+}

--- a/packages/ui/helpers/locales/en.js
+++ b/packages/ui/helpers/locales/en.js
@@ -21,7 +21,8 @@ export default {
       senderNameRequired: 'A Sender name is Required',
       senderMailRequired: 'A Sender email is Required',
       WORKSPACE_ALREADY_EXISTS: 'A workspace with this name already exists',
-      FORBIDDEN_WORKSPACE_CREATION: 'You don\'t have the rights to create this workspace',
+      FORBIDDEN_WORKSPACE_CREATION:
+        'You don\'t have the rights to create this workspace',
       emailsGroupExist: 'The name of this test list already exist',
       password: {
         error: {
@@ -109,6 +110,7 @@ export default {
     edit: 'Edit',
     move: 'Move',
     emailsGroups: 'Test lists',
+    personalizedVariables: 'Personalized variables',
     emailsGroupsEmpty: 'No test list available',
     continue: 'Continue',
     downloadFtp: 'Download FTP',
@@ -127,7 +129,7 @@ export default {
       },
       color: {
         label: 'Custom color',
-       },
+      },
       defaultWorkspace: {
         label: 'Default workspace\'s name',
       },
@@ -151,7 +153,8 @@ export default {
       editorLabel: 'Button label',
       entryPoint: 'Entry point',
       issuer: 'Issuer',
-      userHasAccessToAllWorkspaces: 'Give access to all workspaces to regular users',
+      userHasAccessToAllWorkspaces:
+        'Give access to all workspaces to regular users',
     },
     template: {
       meta: 'Meta',
@@ -194,11 +197,13 @@ export default {
           emailsValid: 'There are invalid email addresses',
         },
       },
-      deleteNotice: 'You are about to delete the test list. This action can\'t be undone.',
+      deleteNotice:
+        'You are about to delete the test list. This action can\'t be undone.',
       deleteSuccess: 'Test list deleted',
     },
     workspace: {
-      checkBoxError: 'I understand that workspace\'s emails and folders will be removed too',
+      checkBoxError:
+        'I understand that workspace\'s emails and folders will be removed too',
       inputError: 'The name is required',
       inputMaxLength: 'Name must not exceed 70 characters',
       moveFolderConfirmationMessage: 'Please choose the destination',
@@ -220,24 +225,31 @@ export default {
     },
     mailingTab: {
       confirmationField: 'Type the email name to confirm',
-      deleteWarningMessage: 'You are about to delete the email: <strong>{name}</strong>.<br/>This action can\'t be undone.',
+      deleteWarningMessage:
+        'You are about to delete the email: <strong>{name}</strong>.<br/>This action can\'t be undone.',
       deleteSuccessful: 'Email deleted',
-      deleteFolderWarning: 'You are about to delete the folder: <strong>{name}</strong> folder.<br/>This action can\'t be undone.',
-      deleteFolderNotice: 'Emails and folders contained in this folder will also be deleted',
+      deleteFolderWarning:
+        'You are about to delete the folder: <strong>{name}</strong> folder.<br/>This action can\'t be undone.',
+      deleteFolderNotice:
+        'Emails and folders contained in this folder will also be deleted',
       deleteFolderSuccessful: 'Folder deleted',
     },
     workspaceTab: {
       confirmationField: 'Type the workspace name to confirm',
-      deleteNotice: 'Emails and folders contained in the workspace will also be deleted',
-      deleteWarningMessage: 'You are about to delete the workspace: <strong>{name}</strong>.<br/>This action can\'t be undone.',
+      deleteNotice:
+        'Emails and folders contained in the workspace will also be deleted',
+      deleteWarningMessage:
+        'You are about to delete the workspace: <strong>{name}</strong>.<br/>This action can\'t be undone.',
       deleteSuccessful: 'Workspace deleted',
     },
     delete: {
-      'deleteWarningMessage': 'You are about to delete the group: <strong>{name}</strong>.<br/>This action can\'t be undone.',
-      'confirmationField': 'Type the group name to confirm',
-      'deleteNotice': 'Administrators, users, templates, workspaces, folders, emails and emails test groups will also be deleted',
-      'successful': 'Group deleted',
-    }
+      deleteWarningMessage:
+        'You are about to delete the group: <strong>{name}</strong>.<br/>This action can\'t be undone.',
+      confirmationField: 'Type the group name to confirm',
+      deleteNotice:
+        'Administrators, users, templates, workspaces, folders, emails and emails test groups will also be deleted',
+      successful: 'Group deleted',
+    },
   },
   mailings: {
     transfer: {
@@ -252,20 +264,25 @@ export default {
       and: 'and',
     },
     deleteManySuccessful: 'Emails deleted',
-    deleteConfirmationMessage: 'You are about to delete all the selected emails.<br/>This action can\'t be undone.',
-    downloadManyMailsWithoutPreview: 'This email list does not contain previews so they will not be downloaded. Do you want to continue anyway?',
-    downloadSingleMailWithoutPreview: 'Cannot download an email without a preview. Please open the email at least once to generate one.',  
+    deleteConfirmationMessage:
+      'You are about to delete all the selected emails.<br/>This action can\'t be undone.',
+    downloadManyMailsWithoutPreview:
+      'This email list does not contain previews so they will not be downloaded. Do you want to continue anyway?',
+    downloadSingleMailWithoutPreview:
+      'Cannot download an email without a preview. Please open the email at least once to generate one.',
     duplicate: 'Duplicate email',
     duplicateNotice: 'Are you sure to duplicate: <strong>{name}</strong> ?',
     name: 'Email name',
     errorPreview: 'No preview available for this email',
-    subErrorPreview: 'A preview will be generated when opening the email editor',
+    subErrorPreview:
+      'A preview will be generated when opening the email editor',
     rename: 'Rename email',
     selectedCount: '{count} email selected | {count} emails selected',
     selectedShortCount: '{count} email| {count} emails',
     deleteCount: 'Delete {count} email | Delete {count} emails',
     downloadCount: 'Download {count} email | Download {count} emails',
-    downloadFtpCount: 'Download ftp {count} email | Download ftp {count} emails',
+    downloadFtpCount:
+      'Download ftp {count} email | Download ftp {count} emails',
     moveCount: 'Move {count} email | Move {count} emails',
     deleteNotice: 'This will definitely remove:',
     copyMailConfirmationMessage: 'Please choose the location of the copy:',
@@ -285,7 +302,8 @@ export default {
     preview: 'Download template',
     removeImages: 'Delete all images',
     imagesRemoved: 'Images deleted',
-    deleteNotice: 'Deleting a template will also remove every emails using this one',
+    deleteNotice:
+      'Deleting a template will also remove every emails using this one',
   },
   tags: {
     list: 'Tags\' list',
@@ -332,9 +350,11 @@ export default {
     edit: 'Edit',
     delete: 'Delete',
     contentSendType: 'The content type',
-    warningNoFTP: 'You cannot add profile without having configured FTP server.',
+    warningNoFTP:
+      'You cannot add profile without having configured FTP server.',
     emptyState: 'No profile available',
-    deleteWarningMessage: 'You are about to delete the profile: <strong>{name}</strong>.<br/>This action can\'t be undone.',
+    deleteWarningMessage:
+      'You are about to delete the profile: <strong>{name}</strong>.<br/>This action can\'t be undone.',
   },
   folders: {
     name: 'Folder name',
@@ -364,5 +384,22 @@ export default {
       transfer: 'Transfer',
     },
   },
-
+  personalizedVariables: {
+    status: 'Status',
+    label: 'Label',
+    variable: 'Variable',
+    actions: 'Actions',
+    addRow: 'Add Row',
+    save: 'Save',
+    delete: 'Delete',
+    deleteNotice: 'Are you sure you want to delete this variable?',
+    validation: {
+      required: 'This field is required.',
+    },
+    snackbars: {
+      deleted: 'Personalized variable deleted successfully.',
+      updated: 'Personalized variables updated successfully.',
+      error: 'An error occurred. Please try again.',
+    },
+  },
 };

--- a/packages/ui/helpers/locales/fr.js
+++ b/packages/ui/helpers/locales/fr.js
@@ -21,7 +21,8 @@ export default {
       senderNameRequired: 'Veuillez saisir un nom d\'expéditeur',
       senderMailRequired: 'Veuillez saisir l\'adresse email de l\'expéditeur',
       WORKSPACE_ALREADY_EXISTS: 'Un workspace avec le même nom existe déjà',
-      FORBIDDEN_WORKSPACE_CREATION: 'Vous n\'avez pas les droits pour créer ce workspace',
+      FORBIDDEN_WORKSPACE_CREATION:
+        'Vous n\'avez pas les droits pour créer ce workspace',
       emailsGroupExist: 'Ce nom de liste de test est déjà utilisé',
       password: {
         error: {
@@ -109,6 +110,7 @@ export default {
     edit: 'Modifier',
     move: 'Déplacer',
     emailsGroups: 'Listes de test',
+    personalizedVariables: 'Variables personnalisées',
     emailsGroupsEmpty: 'Aucune liste de test disponible',
     continue: 'Continuer',
     downloadFtp: 'Télécharger FTP',
@@ -127,7 +129,7 @@ export default {
       },
       color: {
         label: 'Couleurs personnalisées',
-       },
+      },
       defaultWorkspace: {
         label: 'Nom du workspace par défaut',
       },
@@ -151,7 +153,8 @@ export default {
       editorLabel: 'Libellé du bouton',
       entryPoint: 'Point d\'entrée',
       issuer: 'Issuer',
-      userHasAccessToAllWorkspaces: 'Donner accès à tous les workspaces aux utilisateurs standards',
+      userHasAccessToAllWorkspaces:
+        'Donner accès à tous les workspaces aux utilisateurs standards',
     },
     template: {
       meta: 'Meta',
@@ -191,14 +194,17 @@ export default {
         },
         emails: {
           required: 'Veuillez saisir au moins une adresse email',
-          emailsValid: 'Il semblerait qu\'il y ait des adresses emails non valides',
+          emailsValid:
+            'Il semblerait qu\'il y ait des adresses emails non valides',
         },
       },
-      deleteNotice: 'Vous êtes sur le point de supprimer cette liste de test. Cette action est irréversible.',
+      deleteNotice:
+        'Vous êtes sur le point de supprimer cette liste de test. Cette action est irréversible.',
       deleteSuccess: 'La liste de test a bien été supprimé',
     },
     workspace: {
-      checkBoxError: 'Je comprends que les emails et les dossiers contenus dans le workspace seront aussi supprimés',
+      checkBoxError:
+        'Je comprends que les emails et les dossiers contenus dans le workspace seront aussi supprimés',
       inputError: 'Veuillez saisir un nom',
       inputMaxLength: 'Le nom ne doit pas dépasser 70 caractères',
       moveFolderConfirmationMessage: 'Veuillez choisir la destination',
@@ -220,23 +226,30 @@ export default {
     },
     mailingTab: {
       confirmationField: 'Veuillez saisir le nom de l\'email pour confirmer',
-      deleteWarningMessage: 'Vous êtes sur le point de supprimer l\'email : <strong>{name}</strong>.<br/>Cette action est irréversible.',
+      deleteWarningMessage:
+        'Vous êtes sur le point de supprimer l\'email : <strong>{name}</strong>.<br/>Cette action est irréversible.',
       deleteSuccessful: 'L\'email a bien été supprimé',
-      deleteFolderWarning: 'Vous êtes sur le point de supprimer le dossier : <strong>{name}</strong>.<br/>Cette action est irréversible.',
-      deleteFolderNotice: 'Les emails et dossiers contenus dans ce dossier seront également supprimés.',
+      deleteFolderWarning:
+        'Vous êtes sur le point de supprimer le dossier : <strong>{name}</strong>.<br/>Cette action est irréversible.',
+      deleteFolderNotice:
+        'Les emails et dossiers contenus dans ce dossier seront également supprimés.',
       deleteFolderSuccessful: 'Le dossier a bien été supprimé',
     },
     workspaceTab: {
       confirmationField: 'Veuillez saisir le nom du workspace pour confirmer',
-      deleteWarningMessage: 'Vous êtes sur le point de supprimer le workspace : <strong>{name}</strong>.<br/>Cette action est irréversible.',
-      deleteNotice: 'Les emails et dossiers contenus dans ce workspace seront également supprimés.',
+      deleteWarningMessage:
+        'Vous êtes sur le point de supprimer le workspace : <strong>{name}</strong>.<br/>Cette action est irréversible.',
+      deleteNotice:
+        'Les emails et dossiers contenus dans ce workspace seront également supprimés.',
       deleteSuccessful: 'Le workspace a bien été supprimé',
     },
     delete: {
-      'deleteWarningMessage': 'Vous êtes sur le point de supprimer le groupe : <strong>{name}</strong>.<br/>Cette action est irréversible.',
-      'confirmationField': 'Tapez le nom du groupe pour confirmer',
-      'deleteNotice': 'Les administrateurs, utilisteurs, templates, workspaces, répertoires, emails et groupes de testes seront supprimés aussi',
-      'successful': 'Le groupe a bien été supprimé'
+      deleteWarningMessage:
+        'Vous êtes sur le point de supprimer le groupe : <strong>{name}</strong>.<br/>Cette action est irréversible.',
+      confirmationField: 'Tapez le nom du groupe pour confirmer',
+      deleteNotice:
+        'Les administrateurs, utilisteurs, templates, workspaces, répertoires, emails et groupes de testes seront supprimés aussi',
+      successful: 'Le groupe a bien été supprimé',
     },
   },
   mailings: {
@@ -244,7 +257,8 @@ export default {
       label: 'Transférer l\'email',
       success: 'L\'email a bien été transféré',
     },
-    creationNotice: 'Veuillez choisir un template afin de créer un nouvel email',
+    creationNotice:
+      'Veuillez choisir un template afin de créer un nouvel email',
     list: 'Rechercher dans la liste d\'emails',
     filters: {
       createdBetween: 'Créé entre le',
@@ -252,12 +266,16 @@ export default {
       and: 'et le',
     },
     deleteManySuccessful: 'Les emails ont bien été supprimés',
-    deleteConfirmationMessage: 'Vous êtes sur le point de supprimer l\'ensemble des emails sélectionnés.<br/>Cette action est irréversible.',
+    deleteConfirmationMessage:
+      'Vous êtes sur le point de supprimer l\'ensemble des emails sélectionnés.<br/>Cette action est irréversible.',
     duplicate: 'Dupliquer l\'email',
-    duplicateNotice: 'Êtes-vous sûr de vouloir dupliquer l\'email : <strong>{name}</strong> ?',
+    duplicateNotice:
+      'Êtes-vous sûr de vouloir dupliquer l\'email : <strong>{name}</strong> ?',
     name: 'Nom de l\'email',
-    downloadManyMailsWithoutPreview: 'Cette liste d\'emails ne contient pas de prévisualisation, ils ne pourront pas tous être téléchargés. Voulez vous continuer quand même ?',
-    downloadSingleMailWithoutPreview: 'Impossible de télécharger un email sans aperçu. Veuillez ouvrir l\'email dans l\'éditeur pour en générer un.',
+    downloadManyMailsWithoutPreview:
+      'Cette liste d\'emails ne contient pas de prévisualisation, ils ne pourront pas tous être téléchargés. Voulez vous continuer quand même ?',
+    downloadSingleMailWithoutPreview:
+      'Impossible de télécharger un email sans aperçu. Veuillez ouvrir l\'email dans l\'éditeur pour en générer un.',
     errorPreview: 'Pas d’aperçu disponible pour cet email',
     subErrorPreview: 'L\'aperçu sera généré lors de l\'ouverture dans l\'éditeur',
     rename: 'Renommer l\'email',
@@ -265,7 +283,8 @@ export default {
     selectedShortCount: '{count} email | {count} emails',
     deleteCount: 'Supprimer {count} email | Supprimer {count} emails',
     downloadCount: 'Télécharger {count} email | Télécharger {count} emails',
-    downloadFtpCount: 'Télécharger en FTP {count} email | Télécharger en FTP {count} emails',
+    downloadFtpCount:
+      'Télécharger en FTP {count} email | Télécharger en FTP {count} emails',
     moveCount: 'Déplacer {count} email | Déplacer {count} emails',
     deleteNotice: 'Cela supprimera définitivement :',
     copyMailConfirmationMessage: 'Veuillez choisir l\'emplacement de la copie :',
@@ -285,7 +304,8 @@ export default {
     preview: 'Prévisualiser le template',
     removeImages: 'Supprimer toutes les images',
     imagesRemoved: 'Les images ont bien été supprimées',
-    deleteNotice: 'Supprimer un template supprimera aussi tout les emails utilisant ce template',
+    deleteNotice:
+      'Supprimer un template supprimera aussi tout les emails utilisant ce template',
   },
   tags: {
     list: 'Liste des labels',
@@ -333,8 +353,10 @@ export default {
     delete: 'Supprimer',
     contentSendType: 'Le type du contenu',
     emptyState: 'Aucun profil disponible',
-    warningNoFTP: 'Vous ne pouvez pas ajouter de profil sans avoir configuré un serveur FTP au préalable.',
-    deleteWarningMessage: 'Vous êtes sur le point de supprimer le profil : <strong>{name}</strong>.<br/>Cette action est irréversible.',
+    warningNoFTP:
+      'Vous ne pouvez pas ajouter de profil sans avoir configuré un serveur FTP au préalable.',
+    deleteWarningMessage:
+      'Vous êtes sur le point de supprimer le profil : <strong>{name}</strong>.<br/>Cette action est irréversible.',
   },
   folders: {
     name: 'Nom du dossier',
@@ -364,5 +386,22 @@ export default {
       transfer: 'Transférer',
     },
   },
-
+  personalizedVariables: {
+    status: 'Statut',
+    label: 'Libellé',
+    variable: 'Variable',
+    actions: 'Actions',
+    addRow: 'Ajouter une ligne',
+    save: 'Enregistrer',
+    delete: 'Supprimer',
+    deleteNotice: 'Êtes-vous sûr de vouloir supprimer cette variable?',
+    validation: {
+      required: 'Ce champ est requis.',
+    },
+    snackbars: {
+      deleted: 'Variable personnalisée supprimée avec succès.',
+      updated: 'Variables personnalisées mises à jour avec succès.',
+      error: 'Une erreur s\'est produite. Veuillez réessayer.',
+    },
+  },
 };

--- a/packages/ui/routes/groups/_groupId/index.vue
+++ b/packages/ui/routes/groups/_groupId/index.vue
@@ -72,10 +72,12 @@ export default {
 
   watch: {
     activeTab(newTab) {
-      // Replace the URL without causing a navigation or reload
-      this.$router.replace({
-        query: { ...this.$route.query, redirectTab: newTab },
-      });
+      if (newTab !== this.$route.query.redirectTab) {
+        // Replace the URL without causing a navigation or reload
+        this.$router.replace({
+          query: { ...this.$route.query, redirectTab: newTab },
+        });
+      }
     },
   },
   created() {

--- a/packages/ui/routes/groups/_groupId/index.vue
+++ b/packages/ui/routes/groups/_groupId/index.vue
@@ -50,27 +50,38 @@ export default {
       group: {},
       loading: false,
       intersectionObserver: null,
+      activeTab: 'informations',
     };
   },
   head() {
     return { title: this.title };
   },
+
   computed: {
     ...mapGetters(USER, {
       isAdmin: IS_ADMIN,
       isGroupAdmin: IS_GROUP_ADMIN,
     }),
-    tab() {
-      return this.$route.query.redirectTab
-        ? this.$route.query.redirectTab
-        : 'informations';
-    },
     title() {
       return `${this.$tc('global.settings', 1)} : ${this.$tc(
         'global.group',
         1
       )} ${this.group.name}`;
     },
+  },
+
+  watch: {
+    activeTab(newTab) {
+      // Replace the URL without causing a navigation or reload
+      this.$router.replace({
+        query: { ...this.$route.query, redirectTab: newTab },
+      });
+    },
+  },
+  created() {
+    if (this.$route.query.redirectTab) {
+      this.activeTab = this.$route.query.redirectTab;
+    }
   },
   mounted() {
     this.observeVisibility();
@@ -139,31 +150,58 @@ export default {
       <bs-group-menu />
     </template>
     <client-only>
-      <v-tabs ref="tabs" :value="`group-${tab}`" centered>
+      <v-tabs ref="tabs" :value="activeTab" centered>
         <v-tabs-slider color="accent" />
-        <v-tab href="#group-informations">
+        <v-tab
+          href="#group-informations"
+          @click="activeTab = 'group-informations'"
+        >
           {{ $t('groups.tabs.informations') }}
         </v-tab>
-        <v-tab v-if="isAdmin" href="#group-templates">
+        <v-tab
+          v-if="isAdmin"
+          href="#group-templates"
+          @click="activeTab = 'group-templates'"
+        >
           {{ $tc('global.template', 2) }}
         </v-tab>
-        <v-tab v-if="isGroupAdmin" href="#group-workspaces">
+        <v-tab
+          v-if="isGroupAdmin"
+          href="#group-workspaces"
+          @click="activeTab = 'group-workspaces'"
+        >
           {{ $tc('global.teams', 2) }}
         </v-tab>
-        <v-tab href="#group-users">
+        <v-tab href="#group-users" @click="activeTab = 'group-users'">
           {{ $tc('global.user', 2) }}
         </v-tab>
-        <v-tab v-if="isAdmin" href="#group-mailings">
+        <v-tab
+          v-if="isAdmin"
+          href="#group-mailings"
+          @click="activeTab = 'group-mailings'"
+        >
           {{ $tc('global.mailing', 2) }}
         </v-tab>
-        <v-tab v-if="isAdmin" href="#group-profile">
+        <v-tab
+          v-if="isAdmin"
+          href="#group-profile"
+          @click="activeTab = 'group-profile'"
+        >
           {{ $tc('global.profile', 2) }}
         </v-tab>
-        <v-tab v-if="isGroupAdmin" href="#group-emails-groups">
+        <v-tab
+          v-if="isGroupAdmin"
+          href="#group-emails-groups"
+          @click="activeTab = 'group-emails-groups'"
+        >
           {{ $tc('global.emailsGroups', 2) }}
         </v-tab>
-        <v-tab v-if="isGroupAdmin" href="#group-personalized-variables">
-          custom variable
+        <v-tab
+          v-if="isGroupAdmin"
+          href="#group-personalized-variables"
+          @click="activeTab = 'group-personalized-variables'"
+        >
+          {{ $t('global.personalizedVariables') }}
         </v-tab>
         <v-tab-item value="group-informations">
           <bs-group-form

--- a/packages/ui/routes/groups/_groupId/index.vue
+++ b/packages/ui/routes/groups/_groupId/index.vue
@@ -160,6 +160,9 @@ export default {
         <v-tab v-if="isGroupAdmin" href="#group-emails-groups">
           {{ $tc('global.emailsGroups', 2) }}
         </v-tab>
+        <v-tab v-if="isGroupAdmin" href="#group-emails-groups">
+          custom variable
+        </v-tab>
         <v-tab-item value="group-informations">
           <bs-group-form
             v-model="group"

--- a/packages/ui/routes/groups/_groupId/index.vue
+++ b/packages/ui/routes/groups/_groupId/index.vue
@@ -13,6 +13,7 @@ import BsGroupUsersTab from '~/components/group/users-tab.vue';
 import BsGroupWorkspacesTab from '~/components/group/workspaces-tab.vue';
 import BsEmailsGroupsTab from '~/components/group/emails-groups-tab.vue';
 import BsGroupProfilesTab from '~/components/group/profile-tab.vue';
+import GroupPersonalizedVariableTab from '~/components/group/group-personalized-variable-tab';
 import BsGroupLoading from '~/components/loadingBar';
 
 import { IS_ADMIN, IS_GROUP_ADMIN, USER } from '~/store/user';
@@ -29,6 +30,7 @@ export default {
     BsGroupLoading,
     BsGroupProfilesTab,
     BsEmailsGroupsTab,
+    GroupPersonalizedVariableTab,
   },
   mixins: [mixinPageTitle],
   meta: {
@@ -160,7 +162,7 @@ export default {
         <v-tab v-if="isGroupAdmin" href="#group-emails-groups">
           {{ $tc('global.emailsGroups', 2) }}
         </v-tab>
-        <v-tab v-if="isGroupAdmin" href="#group-emails-groups">
+        <v-tab v-if="isGroupAdmin" href="#group-personalized-variables">
           custom variable
         </v-tab>
         <v-tab-item value="group-informations">
@@ -189,6 +191,9 @@ export default {
         </v-tab-item>
         <v-tab-item v-if="isGroupAdmin" value="group-emails-groups">
           <bs-emails-groups-tab />
+        </v-tab-item>
+        <v-tab-item v-if="isGroupAdmin" value="group-personalized-variables">
+          <group-personalized-variable-tab />
         </v-tab-item>
       </v-tabs>
       <bs-group-loading slot="placeholder" />


### PR DESCRIPTION
## Description
The frontend feature will provide an intuitive and user-friendly interface for managing personalized variables within a group's settings. This will be achieved through a new tab named "Custom Variable" in the `BsPageGroup` component.

### Tasks

- [ ] Add a new tab in `BsPageGroup` named "Custom Variable" with the appropriate translations. This will be located in `packages/ui/routes/groups/_groupId/index.vue`.
- [ ] Create a new component `bs-group-personalized-variable-tab`. This will be located in `packages/ui/components/group/bs-group-personalized-variable-tab`.
- [ ] Display text inputs directly for the "label" and "variable" fields. These inputs will be initialized with the respective values, which can be modified. An "Add" button will be available to add new rows to the table.
- [ ] Add a "Delete" button to remove an element. If the deleted element has an id, a backend call is made to delete the element. If it does not have an id, it is deleted without making a backend call because it is not already published.
- [ ] Implement validation on the fields in case they are left empty when the submit button is clicked.

### Example of Visual Table:

To maintain consistency, we should create a table similar to the existing one, but with text inputs directly displayed for the "label" and "variable" fields.

![image](https://github.com/Badsender-com/LePatron.email/assets/80390318/8e302a4d-ee86-494a-976e-13ddd61f0d0d)


### API Endpoints

- **GET** `/api/groups/:groupId/personalized-variables` - This endpoint will be used to retrieve all personalized variables associated with the specified group ID. This will be used to populate the table with existing variables.

- **POST** `/api/groups/:groupId/personalized-variables` - This endpoint will be used to create or update a list of personalized variables in the specified group. The request body should contain the details of the personalized variable array to be created or updated (i.e., label and variable). This will be used when the "Add" button is clicked and when a field is modified.

- **DELETE** `/api/groups/:groupId/personalized-variables/:variableId` - This endpoint will be used to delete a personalized variable from the specified group. This will be used when the "Delete" button is clicked and the element has an id.

### Acceptance Criteria

- [ ] Group admins can add new personalized variables by clicking the "Add" button.
- [ ] Group admins can modify existing personalized variables by editing the value in the text input.
- [ ] Group admins can delete existing personalized variables by clicking the "Delete" button.
- [ ] Changes made to variables are correctly saved and persistent.
- [ ] Validation errors are properly handled and displayed to the user.

### Time Estimation

2 days.

## Result

https://github.com/Badsender-com/LePatron.email/assets/80390318/bca9922d-45ad-4a0b-a868-7cfd3a9e1d25
