### PR TITLE
Save Customized Block in LePatron

### DIFF
--- a/packages/editor/src/css/style_mosaico_content.less
+++ b/packages/editor/src/css/style_mosaico_content.less
@@ -188,7 +188,8 @@
 }
 
 #main-edit-area .tools .tool.delete,
-#main-edit-area .tools .tool.clone {
+#main-edit-area .tools .tool.clone,
+#main-edit-area .tools .tool.save {
   float: right;
   margin-left: 3px;
 }

--- a/packages/editor/src/js/app.js
+++ b/packages/editor/src/js/app.js
@@ -18,8 +18,9 @@ var utilPlugin = require('./ext/util.js');
 var inlinerPlugin = require('./ext/inliner.js');
 
 var localStorageLoader = require('./ext/localstorage.js');
-const espPlugin = require("./vue/espPlugin");
-const trackingParamsPlugin = require("./vue/trackingParamsPlugin");
+const espPlugin = require('./vue/espPlugin');
+const customizedBlockPlugin = require('./vue/customizedBlockPlugin');
+const trackingParamsPlugin = require('./vue/trackingParamsPlugin');
 
 if (typeof ko == 'undefined') throw 'Cannot find knockout.js library!';
 if (typeof $ == 'undefined') throw 'Cannot find jquery library!';
@@ -183,6 +184,7 @@ var start = function (
     utilPlugin,
     inlinerPlugin,
     espPlugin,
+    customizedBlockPlugin,
     trackingParamsPlugin,
   ];
   if (typeof customExtensions !== 'undefined')

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -4,7 +4,6 @@
 var $ = require('jquery');
 var ko = require('knockout');
 var console = require('console');
-const Vue = require('vue/dist/vue.common');
 var performanceAwareCaller = require('./timed-call.js').timedCall;
 
 const MAX_SIZE = 102000;
@@ -51,6 +50,17 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     toggleSaveBlockModal: ko.observable(null),
   };
 
+  /**
+   * In Knockout.js, observables are special JavaScript objects that can notify subscribers about changes,
+   * and can automatically detect dependencies. They are primarily used for two-way data binding,
+   * allowing the UI to automatically update when the underlying data changes, and vice versa.
+   * For more information you can visit the doc : https://knockoutjs.com/documentation/observables.html
+   * 
+   * However, sometimes it's necessary to obtain the raw values from observables, especially when
+   * working with complex data structures that may contain nested observables. The function
+   * `recursivelyUnwrapObservable` is designed to traverse an object and extract the raw values
+   * from any observables it encounters, producing a 'plain' object without any observables.
+   */
   function recursivelyUnwrapObservable(obj) {
     // If 'obj' is an observable, we need to unwrap it to get its actual value.
     // Since this value might also be an observable, we use a recursive call.

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -4,6 +4,7 @@
 var $ = require('jquery');
 var ko = require('knockout');
 var console = require('console');
+const Vue = require('vue/dist/vue.common');
 var performanceAwareCaller = require('./timed-call.js').timedCall;
 
 const MAX_SIZE = 102000;
@@ -47,7 +48,33 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     logoPath: 'rs/img/mosaico32.png',
     logoUrl: '.',
     logoAlt: 'mosaico',
+    toggleSaveBlockModal: ko.observable(null),
   };
+
+  function recursivelyUnwrapObservable(obj) {
+    // If 'obj' is an observable, we need to unwrap it to get its actual value.
+    // Since this value might also be an observable, we use a recursive call.
+    if (ko.isObservable(obj)) {
+      return recursivelyUnwrapObservable(obj());
+    }
+
+    // If 'obj' is an object (but not null), we want to explore its properties.
+    else if (typeof obj === 'object' && obj !== null) {
+      const newObj = {};
+
+      // For each property of 'obj', we check if it contains observables and attempt to unwrap them.
+      for (const key in obj) {
+        if (obj.hasOwnProperty(key)) {
+          newObj[key] = recursivelyUnwrapObservable(obj[key]);
+        }
+      }
+
+      return newObj;
+    }
+
+    // If 'obj' is neither an observable nor an object, it's already a primitive or non-observable value.
+    return obj;
+  }
 
   // viewModel.content = content._instrument(ko, content, undefined, true);
   viewModel.content = content;
@@ -145,6 +172,11 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     if (typeof unwrapped.id !== 'undefined') unwrapped.id = '';
     // insert the cloned block
     parent.blocks.splice(idx + 1, 0, unwrapped);
+  };
+
+  // block-wysiwyg.tmpl.html
+  viewModel.saveBlock = function (data) {
+    viewModel.toggleSaveBlockModal(true, data);
   };
 
   // block-wysiwyg.tmpl.html

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -175,8 +175,9 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
   };
 
   // block-wysiwyg.tmpl.html
-  viewModel.saveBlock = function (data) {
-    viewModel.toggleSaveBlockModal(true, data);
+  viewModel.saveBlock = function (data, parent) {
+    const actualData = recursivelyUnwrapObservable(data);
+    viewModel.toggleSaveBlockModal(true, actualData);
   };
 
   // block-wysiwyg.tmpl.html

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -92,7 +92,7 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
                 @click.prevent="closeModal"
                 class="btn-flat waves-effect waves-light"
                 name="closeAction">
-                {{ vm.t('close') }}
+                {{ vm.t('block-modal-close') }}
             </button>
             <button
                 @click.prevent="handleOnSubmit"

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -1,0 +1,112 @@
+const Vue = require('vue/dist/vue.common');
+const { ModalComponent } = require('../modal/modalComponent');
+const styleHelper = require('../../utils/style/styleHelper');
+
+const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
+  components: {
+    ModalComponent,
+  },
+  props: {
+    vm: { type: Object, default: () => ({}) },
+  },
+  data: () => ({
+    blockName: '',
+    blockCategory: '',
+    blockInformation: null,
+    style: styleHelper,
+    subscriptions: [],
+  }),
+  mounted() {
+    this.vm.toggleSaveBlockModal = this.handleToggleSaveBlockModalChange;
+  },
+  computed: {
+    disableSaveButton() {
+      return !this.blockName; // Disable the button if blockName is empty
+    },
+  },
+  methods: {
+    openModal() {
+      this.$refs.modalRef?.openModal();
+    },
+    closeModal() {
+      this.blockName = '';
+      this.blockCategory = '';
+      this.blockInformation = null;
+      this.$refs.modalRef?.closeModal();
+    },
+    handleToggleSaveBlockModalChange(value, data) {
+      if (value === true) {
+        this.openModal();
+        this.blockInformation = data;
+      } else {
+        this.closeModal();
+        this.blockInformation = null;
+      }
+    },
+    handleOnSubmit() {
+      // Logic to handle the submission of the block details
+      // This can be expanded upon based on your requirements
+      console.log(
+        'Block details submitted:',
+        this.blockName,
+        this.blockCategory,
+        this.blockInformation
+      );
+      this.closeModal();
+    },
+  },
+  template: `
+    <modal-component 
+        ref="modalRef">
+        <div class="modal-content" :onClose="closeModal">
+            <div class="row">
+                <div class="col s12">
+                    <h5>{{vm.t('title-save-block')}}</h5>
+                </div>
+                <form class="col s12">
+                    <div class="row">
+                        <div class="input-field col s12">
+                            <input
+                              id="blockName"
+                              v-model="blockName"
+                              type="text"
+                              name="blockName"
+                              placeholder="Enter block name">
+                            <label for="blockName">{{ vm.t('block-name') }}</label>
+                        </div>
+                        <div class="input-field col s12">
+                            <input
+                              id="blockCategory"
+                              v-model="blockCategory"
+                              type="text"
+                              name="blockCategory"
+                              placeholder="Enter block category (optional)">
+                            <label for="blockCategory">{{ vm.t('block-category') }}</label>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button
+                @click.prevent="closeModal"
+                class="btn-flat waves-effect waves-light"
+                name="closeAction">
+                {{ vm.t('close') }}
+            </button>
+            <button
+                @click.prevent="handleOnSubmit"
+                :disabled="disableSaveButton"
+                class="btn waves-effect waves-light"
+                type="submit"
+                name="submitAction">
+                {{ vm.t('save-block') }}
+            </button>
+        </div>
+    </modal-component>
+    `,
+});
+
+module.exports = {
+  SaveBlockModalComponent,
+};

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -44,14 +44,7 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
       }
     },
     handleOnSubmit() {
-      // Logic to handle the submission of the block details
-      // This can be expanded upon based on your requirements
-      console.log(
-        'Block details submitted:',
-        this.blockName,
-        this.blockCategory,
-        this.blockInformation
-      );
+      // TODO: Add Logic to handle the submission of the block details
       this.closeModal();
     },
   },
@@ -71,8 +64,8 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
                               v-model="blockName"
                               type="text"
                               name="blockName"
-                              placeholder="Enter block name">
-                            <label for="blockName">{{ vm.t('block-name') }}</label>
+                              :placeholder="vm.t('placeholder-block-name')">
+                              <label for="blockName">{{ vm.t('block-name') }}</label>
                         </div>
                         <div class="input-field col s12">
                             <input
@@ -80,8 +73,8 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
                               v-model="blockCategory"
                               type="text"
                               name="blockCategory"
-                              placeholder="Enter block category (optional)">
-                            <label for="blockCategory">{{ vm.t('block-category') }}</label>
+                              :placeholder="vm.t('placeholder-block-category')">
+                              <label for="blockCategory">{{ vm.t('block-category') }}</label>
                         </div>
                     </div>
                 </form>

--- a/packages/editor/src/js/vue/components/send-test/test-modal.js
+++ b/packages/editor/src/js/vue/components/send-test/test-modal.js
@@ -50,6 +50,7 @@ const TestModalComponent = Vue.component('TestModal', {
     openModal() {
       this.$refs.modalRef?.openModal();
     },
+    
     closeModal() {
       this.inputEmailsTest = '';
       this.selectedEmailGroup = null;

--- a/packages/editor/src/js/vue/components/send-test/test-modal.js
+++ b/packages/editor/src/js/vue/components/send-test/test-modal.js
@@ -11,7 +11,7 @@ const axios = require('axios');
 const TestModalComponent = Vue.component('TestModal', {
   components: {
     ModalComponent,
-    SelectComponent
+    SelectComponent,
   },
   mixins: [validationMixin],
   props: {
@@ -24,17 +24,24 @@ const TestModalComponent = Vue.component('TestModal', {
     isLoadingEmailGroups: false,
     subscriptions: [],
     style: styleHelper,
-    emailsGroups: []
+    emailsGroups: [],
   }),
   computed: {
-    disableSendTestSubmitButton () {
-      return  this.isLoading || 
-              this.$v.$invalid ||
-              ( (!this.selectedEmailGroup || !this.selectedEmailGroup.code) && !this.inputEmailsTest)
+    disableSendTestSubmitButton() {
+      return (
+        this.isLoading ||
+        this.$v.$invalid ||
+        ((!this.selectedEmailGroup || !this.selectedEmailGroup.code) &&
+          !this.inputEmailsTest)
+      );
     },
     displayEmailsGroupsSelect() {
-      return !this.isLoadingEmailGroups && Array.isArray(this.emailsGroups) && this.emailsGroups.length > 0 ;
-    }
+      return (
+        !this.isLoadingEmailGroups &&
+        Array.isArray(this.emailsGroups) &&
+        this.emailsGroups.length > 0
+      );
+    },
   },
   mounted() {
     this.subscriptions = [
@@ -50,7 +57,6 @@ const TestModalComponent = Vue.component('TestModal', {
     openModal() {
       this.$refs.modalRef?.openModal();
     },
-    
     closeModal() {
       this.inputEmailsTest = '';
       this.selectedEmailGroup = null;
@@ -66,48 +72,59 @@ const TestModalComponent = Vue.component('TestModal', {
     },
     fetchEmailsGroups() {
       this.isLoadingEmailGroups = true;
-      return axios.get(getEmailGroups({groupId: this.vm?.metadata?.groupId }))
-          .then((response) => {
-            const { items: emailsGroups } = response.data;
-            this.emailsGroups = emailsGroups.map(emailsGroup => ({
-              label: emailsGroup.name,
-              code: emailsGroup.id
-            }));
-            M.updateTextFields();
-        }).catch((error) => {
-            console.error(error);
-        }).finally(()=> {
+      return axios
+        .get(getEmailGroups({ groupId: this.vm?.metadata?.groupId }))
+        .then((response) => {
+          const { items: emailsGroups } = response.data;
+          this.emailsGroups = emailsGroups.map((emailsGroup) => ({
+            label: emailsGroup.name,
+            code: emailsGroup.id,
+          }));
+          M.updateTextFields();
+        })
+        .catch((error) => {
+          console.error(error);
+        })
+        .finally(() => {
           this.isLoadingEmailGroups = false;
         });
     },
     handleOnSubmit() {
       this.$v.$touch();
-      
+
       if (!this.$v.$invalid) {
-        this.sendTestData({ inputEmailsTest: this.$v.inputEmailsTest.$model});
+        this.sendTestData({ inputEmailsTest: this.$v.inputEmailsTest.$model });
       }
     },
     sendTestData({ inputEmailsTest }) {
       this.isLoading = true;
-      let sendTestEmailsData = { 
+      let sendTestEmailsData = {
         rcpt: inputEmailsTest,
-        html: this.vm.exportHTML()
+        html: this.vm.exportHTML(),
       };
-      
-      if(this.selectedEmailGroup && this.selectedEmailGroup?.code) {
-        sendTestEmailsData = { ...sendTestEmailsData, emailsGroupId: this.selectedEmailGroup?.code }
+
+      if (this.selectedEmailGroup && this.selectedEmailGroup?.code) {
+        sendTestEmailsData = {
+          ...sendTestEmailsData,
+          emailsGroupId: this.selectedEmailGroup?.code,
+        };
       }
-      
-      return axios.post(sendTestEmails({ mailingId: this.vm?.metadata?.id }), sendTestEmailsData)
-      .then( () => {
-        this.vm.notifier.success(this.vm.t('send-test-success'));
-      }).catch(() => {
-        this.vm.notifier.error(this.vm.t('send-test-error'));
-      })
-      .finally(() => {
-        this.isLoading = false;
-        this.closeModal();
-      });
+
+      return axios
+        .post(
+          sendTestEmails({ mailingId: this.vm?.metadata?.id }),
+          sendTestEmailsData
+        )
+        .then(() => {
+          this.vm.notifier.success(this.vm.t('send-test-success'));
+        })
+        .catch(() => {
+          this.vm.notifier.error(this.vm.t('send-test-error'));
+        })
+        .finally(() => {
+          this.isLoading = false;
+          this.closeModal();
+        });
     },
     handleOnInput() {
       this.$v.inputEmailsTest.$touch();
@@ -179,7 +196,7 @@ const TestModalComponent = Vue.component('TestModal', {
     return {
       inputEmailsTest: {
         allMustBeEmails(value) {
-          if(!value) {
+          if (!value) {
             return true;
           }
 

--- a/packages/editor/src/js/vue/customizedBlockPlugin.js
+++ b/packages/editor/src/js/vue/customizedBlockPlugin.js
@@ -1,0 +1,27 @@
+const Vue = require('vue/dist/vue.common');
+const {
+  SaveBlockModalComponent,
+} = require('./components/save-block-modal/save-modal');
+
+module.exports = {
+  viewModel(vm, ko) {},
+  init(vm) {
+    // Init VueJS component
+
+    Vue.component('CustomizedBlockPlugin', {
+      components: {
+        SaveBlockModalComponent,
+      },
+      data: () => ({
+        viewModel: vm,
+      }),
+      template: `
+        <div>
+          <save-block-modal :vm="viewModel"></save-block-modal>
+        </div>
+      `,
+    });
+
+    new Vue({ el: '#customizedBlockModal' });
+  },
+};

--- a/packages/editor/src/js/vue/espPlugin.js
+++ b/packages/editor/src/js/vue/espPlugin.js
@@ -1,6 +1,7 @@
 const Vue = require('vue/dist/vue.common');
 const EspComponent = require('./components/esp/esp-send-mail');
 const { TestModalComponent } = require('./components/send-test/test-modal');
+const { SaveBlockModalComponent } = require('./components/save-block-modal/save-modal');
 
 
 module.exports = {
@@ -12,6 +13,7 @@ module.exports = {
       components: {
         EspComponent,
         TestModalComponent,
+        SaveBlockModalComponent
       },
       data: () => ({
         viewModel: vm,
@@ -23,7 +25,8 @@ module.exports = {
         <div>
           <esp-form :vm="viewModel"></esp-form>
           <test-modal-component :vm="viewModel"></test-modal-component>
-        </div>
+          <save-block-modal :vm="viewModel"></save-block-modal>
+          </div>
       `,
     });
 

--- a/packages/editor/src/js/vue/espPlugin.js
+++ b/packages/editor/src/js/vue/espPlugin.js
@@ -1,8 +1,6 @@
 const Vue = require('vue/dist/vue.common');
 const EspComponent = require('./components/esp/esp-send-mail');
 const { TestModalComponent } = require('./components/send-test/test-modal');
-const { SaveBlockModalComponent } = require('./components/save-block-modal/save-modal');
-
 
 module.exports = {
   viewModel(vm, ko) {},
@@ -13,20 +11,15 @@ module.exports = {
       components: {
         EspComponent,
         TestModalComponent,
-        SaveBlockModalComponent
       },
       data: () => ({
         viewModel: vm,
       }),
-      mounted() {
-
-      },
       template: `
         <div>
           <esp-form :vm="viewModel"></esp-form>
           <test-modal-component :vm="viewModel"></test-modal-component>
-          <save-block-modal :vm="viewModel"></save-block-modal>
-          </div>
+        </div>
       `,
     });
 

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -3,6 +3,9 @@
   <div id="espModal">
     <esp-plugin />
   </div>
+  <div id="customizedBlockModal">
+    <customized-block-plugin />
+  </div>
   <div class="tooltabs__top-bar">
     <a class="tooltabs__top-logo" href="/" data-bind="attr: { href: $root.logoUrl }">
       <img data-bind="attr: { src: $root.logoPath, alt: $root.logoAlt }" alt="mosaico"  />

--- a/packages/editor/src/tmpl/block-wysiwyg.tmpl.html
+++ b/packages/editor/src/tmpl/block-wysiwyg.tmpl.html
@@ -11,6 +11,8 @@
     <!-- /ko -->
     <div title="Delete block" class="tool delete" data-bind="attr: { title: $root.t('Delete block') }, click: $root.removeBlock.bind($element, $rawData, $parent)"><i class="fa fa-fw fa-trash-o"></i></div>
     <div title="Duplicate block" class="tool clone" data-bind="attr: { title: $root.t('Duplicate block') }, click: $root.duplicateBlock.bind($element, $index, $parent)"><i class="fa fa-fw fa-files-o"></i></div>
+    <!-- New Save Block Button -->
+    <div title="Save block" class="tool save" data-bind="attr: { title: $root.t('Save block') }, click: $root.saveBlock.bind($element, $rawData, $parent)"><i class="fa fa-fw fa-download"></i></div>
     <!-- /ko -->
     <!-- ko if: typeof $data._nextVariant != 'undefined' --><div title="Switch block variant" class="tool variant" data-bind="attr: { title: $root.t('Switch block variant') }, click: $data._nextVariant"><i class="fa fa-fw fa-magic"></i></div><!-- /ko -->
   </div>

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -97,4 +97,11 @@ module.exports = {
   'placeholder-emails-groups': 'Select a list',
   'sending-test-mails': 'Sending test mail…',
   'send-test-mails': 'Send',
+
+  // SaveBlockModal translations
+  'title-save-block': 'Save Block',
+  'block-name': 'Block Name',
+  'block-category': 'Block Category',
+  close: 'Close',
+  'save-block': 'Save Block',
 };

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -102,6 +102,6 @@ module.exports = {
   'title-save-block': 'Save Block',
   'block-name': 'Block Name',
   'block-category': 'Block Category',
-  close: 'Close',
+  'block-modal-close': 'Close',
   'save-block': 'Save Block',
 };

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -104,4 +104,6 @@ module.exports = {
   'block-category': 'Block Category',
   'block-modal-close': 'Close',
   'save-block': 'Save Block',
+  'placeholder-block-name': 'Enter block name',
+  'placeholder-block-category': 'Enter block category (optional)',
 };

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -103,6 +103,6 @@ module.exports = {
   'title-save-block': 'Enregistrer le Bloc',
   'block-name': 'Nom du Bloc',
   'block-category': 'Catégorie du Bloc',
-  close: 'Fermer',
+  'block-modal-close': 'Fermer',
   'save-block': 'Enregistrer le Bloc',
 };

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -105,4 +105,6 @@ module.exports = {
   'block-category': 'Catégorie du Bloc',
   'block-modal-close': 'Fermer',
   'save-block': 'Enregistrer le Bloc',
+  'placeholder-block-name': 'Entrez le nom du bloc',
+  'placeholder-block-category': 'Entrez la catégorie du bloc (optionnel)',
 };

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -98,4 +98,11 @@ module.exports = {
   'placeholder-emails-groups': 'Sélectionnez une liste',
   'sending-test-mails': "Envoi de l'email de test…",
   'send-test-mails': 'Envoyer',
+
+  // SaveBlockModal translations
+  'title-save-block': 'Enregistrer le Bloc',
+  'block-name': 'Nom du Bloc',
+  'block-category': 'Catégorie du Bloc',
+  close: 'Fermer',
+  'save-block': 'Enregistrer le Bloc',
 };

--- a/public/lang/mosaico-en.json
+++ b/public/lang/mosaico-en.json
@@ -67,6 +67,7 @@
   "Move this block downside": "Move this block downside",
   "Delete block": "Delete block",
   "Duplicate block": "Duplicate block",
+  "Save block": "Save block",
   "Switch block variant": "Switch block variant",
   "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.": "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.",
   "Drop here": "Drop here",

--- a/public/lang/mosaico-fr.json
+++ b/public/lang/mosaico-fr.json
@@ -67,6 +67,7 @@
   "Move this block downside": "Déplacer ce bloc vers le bas",
   "Delete block": "Supprimer ce bloc",
   "Duplicate block": "Dupliquer ce bloc",
+  "Save block": "Sauvegarder ce bloc",
   "Switch block variant": "Changer la version du bloc",
   "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.": "Couleurs de thème, Couleurs standard, Couleurs web, Couleurs de thème, Retour à la palette, Historique, Pas encore d'historique",
   "Drop here": "Déposer ici",


### PR DESCRIPTION
## Feature: Save Customized Block in LePatron

### Description:
The primary goal of this feature is to allow users of LePatron to save an existing block after customizing it. This will enable them to add it to their predefined block library for future reuse.

### Implementation Details:

#### Directory:
**`packages/editor/src/js/ext`**

#### Steps:

1. **Modal for Saving Block Attributes**: create a new file save-block-modal based on the other modals in the editor, for example: `packages/editor/src/js/vue/components/send-test/test-modal.js`
   - Path: `packages/editor/src/js/ext/save-block-modal.js`
   - Task:
     - Upon clicking the save button, a modal will pop up.
     - The modal will have two text input fields:
       * Name (mandatory)
       * Category (optional)
     - The "Save" button within the modal will be disabled initially.

2. **Integrate Save Button in block-wysiwyg.tmpl.html**:
   - Path: `packages/editor/src/tmpl/block-wysiwyg.tmpl.html`
   - Task:
     - Add a new button with a Font Awesome icon for saving the block.
     - This button will be placed alongside other block tools like delete, duplicate, etc.

3. **Control Button Behavior in viewmodel.js**: in this file we already defined the role of the buttons duplicate and delete and here we need to define the behavior of save block button
   - Path: `packages/editor/src/js/viewmodel.js`
   - Task:
     - Define the behavior of the save button.
     - When clicked, it should trigger the modal from `save-block-modal.js`.

### Acceptance Criteria:

- A new "Save" button is present in the central block editor.
- Clicking the "Save" button opens a modal with fields for "Name" and "Category".

### Result:
**Example after saving the block:**

![Save Block Example](https://user-images.githubusercontent.com/5319082/121906728-afb38e00-cd2b-11eb-824a-a3bd4d9d3164.png)
