### PR TITLE
Add Tabs for "Blocs par défaut" and "Blocs personnalisés" in the Left Sidebar

### DIFF
--- a/packages/editor/src/css/badesender-image-gallery.less
+++ b/packages/editor/src/css/badesender-image-gallery.less
@@ -173,43 +173,6 @@
   }
 }
 
-.blocks-tabs-horizontal {
-  background: var(--v-primary-base);
-  height: 2.6rem;
-  display: flex;
-}
-
-.blocks-tabs-horizontal .blocks-tab-item,
-.blocks-tabs-horizontal .blocks-tab-active {
-  margin: 0;
-  padding-left: 1em;
-  padding-right: 1em;
-  cursor: pointer;
-  height: 100%;
-  flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 0.3em;
-  font-size: 1.1em;
-}
-
-.blocks-tabs-horizontal .blocks-tab-item {
-  color: white;
-  background: var(--v-primary-base);
-}
-
-.blocks-tabs-horizontal .blocks-tab-active {
-  background: white;
-  color: var(--v-primary-base);
-}
-
-.coming-soon {
-  font-style: italic;
-  font-size: 1.2em;
-  color: grey;
-  margin-top: 3rem;
-}
-
 //----- IMAGE GALLERY DIALOG
 
 @dialog-margin: 32px;

--- a/packages/editor/src/css/badesender-image-gallery.less
+++ b/packages/editor/src/css/badesender-image-gallery.less
@@ -173,14 +173,14 @@
   }
 }
 
-.custom-tabs-horizontal {
+.blocks-tabs-horizontal {
   background: var(--v-primary-base);
   height: 2.6rem;
   display: flex;
 }
 
-.custom-tabs-horizontal .custom-tab-item,
-.custom-tabs-horizontal .custom-tab-active {
+.blocks-tabs-horizontal .blocks-tab-item,
+.blocks-tabs-horizontal .blocks-tab-active {
   margin: 0;
   padding-left: 1em;
   padding-right: 1em;
@@ -193,14 +193,21 @@
   font-size: 1.1em;
 }
 
-.custom-tabs-horizontal .custom-tab-item {
-  color: rgba(255, 255, 255, 0.75);
+.blocks-tabs-horizontal .blocks-tab-item {
+  color: white;
   background: var(--v-primary-base);
 }
 
-.custom-tabs-horizontal .custom-tab-active {
+.blocks-tabs-horizontal .blocks-tab-active {
   background: white;
   color: var(--v-primary-base);
+}
+
+.coming-soon {
+  font-style: italic;
+  font-size: 1.2em;
+  color: grey;
+  margin-top: 3rem;
 }
 
 //----- IMAGE GALLERY DIALOG

--- a/packages/editor/src/css/badesender-image-gallery.less
+++ b/packages/editor/src/css/badesender-image-gallery.less
@@ -150,9 +150,19 @@
         padding-left: 1em;
         padding-right: 1em;
       }
+
+      button {
+        padding-left: 1em;
+        padding-right: 1em;
+        background: inherit;
+        border: none;
+        color: inherit;
+      }
+
       &:not(.ui-state-active) {
         color: rgba(255, 255, 255, 0.75);
       }
+
       &.ui-state-active a {
         background: white;
       }
@@ -161,6 +171,36 @@
   .ui-tabs-panel {
     border: 0;
   }
+}
+
+.custom-tabs-horizontal {
+  background: var(--v-primary-base);
+  height: 2.6rem;
+  display: flex;
+}
+
+.custom-tabs-horizontal .custom-tab-item,
+.custom-tabs-horizontal .custom-tab-active {
+  margin: 0;
+  padding-left: 1em;
+  padding-right: 1em;
+  cursor: pointer;
+  height: 100%;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.3em;
+  font-size: 1.1em;
+}
+
+.custom-tabs-horizontal .custom-tab-item {
+  color: rgba(255, 255, 255, 0.75);
+  background: var(--v-primary-base);
+}
+
+.custom-tabs-horizontal .custom-tab-active {
+  background: white;
+  color: var(--v-primary-base);
 }
 
 //----- IMAGE GALLERY DIALOG

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -708,14 +708,6 @@
     display: inline-block;
   }
 
-  .blocks-tabs {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    font-size: 1em;
-  }
-
   .draggable-item .block {
     // margin: 3px;
     .handle {
@@ -765,6 +757,51 @@
         box-shadow: 0 0 15px @mosaico-shadow-color;
       }
     }
+  }
+
+  .blocks-tabs {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    font-size: 1em;
+  }
+
+  .blocks-tabs-horizontal {
+    background: var(--v-primary-base);
+    height: 2.6rem;
+    display: flex;
+  }
+
+  .blocks-tabs-horizontal .blocks-tab-item,
+  .blocks-tabs-horizontal .blocks-tab-active {
+    margin: 0;
+    padding-left: 1em;
+    padding-right: 1em;
+    cursor: pointer;
+    height: 100%;
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
+    font-size: 1.1em;
+  }
+
+  .blocks-tabs-horizontal .blocks-tab-item {
+    color: white;
+    background: var(--v-primary-base);
+  }
+
+  .blocks-tabs-horizontal .blocks-tab-active {
+    background: white;
+    color: var(--v-primary-base);
+  }
+
+  .coming-soon {
+    font-style: italic;
+    font-size: 1.2em;
+    color: grey;
+    margin-top: 3rem;
   }
 
   .blockType {

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -686,6 +686,7 @@
       }
     }
     .ui-tabs-panel {
+      
       margin: 0;
       padding: 0.7em;
       position: absolute;

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -662,7 +662,7 @@
 
         a {
           width: 100%;
-          padding: 0 .75em;
+          padding: 0 0.75em;
         }
         /*
         a {
@@ -686,14 +686,12 @@
       }
     }
     .ui-tabs-panel {
-      
       margin: 0;
       padding: 0.7em;
       position: absolute;
       bottom: @ui-tabs-panel-padding;
       left: @ui-tabs-panel-padding;
       right: @ui-tabs-panel-padding;
-      z-index: 100;
       background-color: @mosaico-background-color;
     }
   }
@@ -708,6 +706,14 @@
     border: 2px solid black;
     z-index: 100;
     display: inline-block;
+  }
+
+  .blocks-tabs {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    font-size: 1em;
   }
 
   .draggable-item .block {
@@ -765,6 +771,10 @@
     display: none;
   }
   .block-list {
+    position: absolute;
+    inset: 0;
+    top: 3rem;
+    padding: 0.7em;
     // suppongo che le immagini siano create per i 340px
     max-width: 346px;
   }

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -692,6 +692,7 @@
       bottom: @ui-tabs-panel-padding;
       left: @ui-tabs-panel-padding;
       right: @ui-tabs-panel-padding;
+      z-index: 100;
       background-color: @mosaico-background-color;
     }
   }

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -49,7 +49,7 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     logoAlt: 'mosaico',
     toggleSaveBlockModal: ko.observable(null),
     // Adding observables to manage "Default Blocks" and "Personalized Blocks" tabs
-    blocksActiveTab: ko.observable('PERSONALIZED_BLOCKS'), // The name of the active tab ("DEFAULT_BLOCKS" or "PERSONALIZED_BLOCKS")
+    blocksActiveTab: ko.observable('TEMPLATE_BLOCKS'), // The name of the active tab ("TEMPLATE_BLOCKS" or "CUSTOM_BLOCKS")
   };
 
   /**

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -49,7 +49,7 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     logoAlt: 'mosaico',
     toggleSaveBlockModal: ko.observable(null),
     // Adding observables to manage "Default Blocks" and "Personalized Blocks" tabs
-    blocksActiveTab: ko.observable('DEFAULT_BLOCKS'), // The name of the active tab ("DEFAULT_BLOCKS" or "PERSONALIZED_BLOCKS")
+    blocksActiveTab: ko.observable('PERSONALIZED_BLOCKS'), // The name of the active tab ("DEFAULT_BLOCKS" or "PERSONALIZED_BLOCKS")
   };
 
   /**

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -48,6 +48,8 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     logoUrl: '.',
     logoAlt: 'mosaico',
     toggleSaveBlockModal: ko.observable(null),
+    // Adding observables to manage "Default Blocks" and "Personalized Blocks" tabs
+    blocksActiveTab: ko.observable('DEFAULT_BLOCKS'), // The name of the active tab ("DEFAULT_BLOCKS" or "PERSONALIZED_BLOCKS")
   };
 
   /**

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -25,16 +25,16 @@
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div id="blockTabs" class="custom-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <div class="custom-tab-item" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }, css: { 'custom-tab-active': $root.blocksActiveTab() === 'DEFAULT_BLOCKS' }">
+    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'DEFAULT_BLOCKS' }">
         <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
       </div>
-      <div class="custom-tab-item" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }, css: { 'custom-tab-active': $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS' }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS' }">
         <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
       </div>
     </div>
     
-    <div id="DEFAULT_BLOCKS" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+    <div data-bind="visible: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
       <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
         <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
           <div class="block"
@@ -54,8 +54,8 @@
         </div>
       </div>
     </div>
-    <div id="PERSONALIZED_BLOCKS" data-bind="if: $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS'">
-      EMPTY LIST
+    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS'">
+      Coming Soon
     </div>
   </div>
 

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -8,25 +8,63 @@
   </div>
   <div class="tooltabs__top-bar">
     <a class="tooltabs__top-logo" href="/" data-bind="attr: { href: $root.logoUrl }">
-      <img data-bind="attr: { src: $root.logoPath, alt: $root.logoAlt }" alt="mosaico"  />
+      <img data-bind="attr: { src: $root.logoPath, alt: $root.logoAlt }" alt="mosaico" />
     </a>
     <ul class="tooltabs__list">
-      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Blocks ready to be added to the template" data-local="true" href="#toolblocks" data-bind="attr: { title: $root.t('Blocks ready to be added to the template') }"><i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Blocks')">Blocks</span></a></li>
-      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit content options" href="#toolcontents" data-local="true" data-bind="attr: { title: $root.t('Edit content options') }"><i class="fa fa-fw fa-pencil"></i> <span data-bind="html: $root.t('Content')">Content</span></a></li>
-      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit style options" href="#toolstyles" data-local="true" data-bind="attr: { title: $root.t('Edit style options') }"><i class="fa fa-fw fa-paint-brush"></i> <span data-bind="html: $root.t('Style')">Style</span></a></li>
-   </ul>
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Blocks ready to be added to the template"
+          data-local="true" href="#toolblocks"
+          data-bind="attr: { title: $root.t('Blocks ready to be added to the template') }"><i
+            class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Blocks')">Blocks</span></a></li>
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit content options" href="#toolcontents"
+          data-local="true" data-bind="attr: { title: $root.t('Edit content options') }"><i
+            class="fa fa-fw fa-pencil"></i> <span data-bind="html: $root.t('Content')">Content</span></a></li>
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit style options" href="#toolstyles"
+          data-local="true" data-bind="attr: { title: $root.t('Edit style options') }"><i
+            class="fa fa-fw fa-paint-brush"></i> <span data-bind="html: $root.t('Style')">Style</span></a></li>
+    </ul>
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
-      <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
-        <div class="block" data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock" style="position: relative;">
-          <div title="Click or drag to add this block to the template" class="handle" data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}"></div>
-          <img data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(type) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }" alt="__name__" />
-          <span class="block-name" data-bind="html: $root.t('__name__', { name: ko.utils.unwrapObservable(type) })">__name__</span>
+    <div id="blockTabs" class="tabs_horizontal button_color blocks-tabs"
+      data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <ul>
+        <!-- Tab for Default Blocks -->
+        <li data-bind="tooltips: {}">
+          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }">
+            <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
+          </a>
+        </li>
+
+        <!-- Tab for Personalized Blocks -->
+        <li data-bind="tooltips: {}">
+          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }">
+            <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div id="template-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+      <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
+        <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
+          <div class="block"
+            data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock"
+            style="position: relative;">
+            <div title="Click or drag to add this block to the template" class="handle"
+              data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
+            </div>
+            <img
+              data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(type) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
+              alt="__name__" />
+            <span class="block-name"
+              data-bind="html: $root.t('__name__', { name: ko.utils.unwrapObservable(type) })">__name__</span>
+          </div>
+          <a href="javascript:void(0)" class="addblockbutton"
+            data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
         </div>
-        <a href="javascript:void(0)" class="addblockbutton" data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
       </div>
+    </div>
+    <div id="-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+      EMPTY LIST
     </div>
   </div>
 
@@ -35,7 +73,9 @@
     <div data-bind="block: $root.selectedBlock"></div>
     <!-- /ko -->
     <!-- ko if: $root.selectedBlock() == null -->
-    <div class="noSelectedBlock" data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">By clicking on message parts you will select a block and content options, if any, will show here</div>
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
+      By clicking on message parts you will select a block and content options, if any, will show here</div>
     <!-- /ko -->
     <!-- ko block: content -->content<!-- /ko -->
     <div id="tracking-params">
@@ -45,18 +85,22 @@
 
   <div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
     <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
-      <!-- ko if: $root.selectedBlock() !== null -->
-      <div data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }"></div>
-      <!-- /ko -->
-      <!-- ko if: $root.selectedBlock() == null -->
-      <div class="noSelectedBlock" data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">By clicking on message parts you will select a block and style options, if available, will show here</div>
-      <!-- /ko -->
-      <div class="workGlobalContent">
+    <!-- ko if: $root.selectedBlock() !== null -->
+    <div
+      data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $root.selectedBlock() == null -->
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
+      By clicking on message parts you will select a block and style options, if available, will show here</div>
+    <!-- /ko -->
+    <div class="workGlobalContent">
       <!-- ko block: content --><!-- /ko -->
-      </div>
+    </div>
     <!-- /ko -->
   </div>
-<//div>div>
+</div>
 
 <div id="toolimages" class="slidebar" data-bind="scrollable: true, css: { hidden: $root.showGallery() === false }">
   <div class="close" data-bind="click: $root.showGallery.bind($element, false);">X</div>
@@ -65,29 +109,51 @@
   <!-- ko if: $root.showGallery() -->
   <div id="toolimagestab" class="tabs_horizontal" data-bind="tabs: { active: $root.selectedImageTab }">
     <ul>
-      <li data-bind="tooltips: {}"><a title="gallery-mailing" data-local="true" href="#toolimagesgallery" data-bind="attr: { title: $root.t('gallery-mailing') }, text: $root.t('gallery-mailing')">gallery-mailing</a></li>
-      <li data-bind="tooltips: {}"><a title="gallery-template" data-local="true" href="#toolimagesgallerytemplate" data-bind="attr: { title: $root.t('gallery-template') }, text: $root.t('gallery-template')">gallery-template</a></li>
+      <li data-bind="tooltips: {}"><a title="gallery-mailing" data-local="true" href="#toolimagesgallery"
+          data-bind="attr: { title: $root.t('gallery-mailing') }, text: $root.t('gallery-mailing')">gallery-mailing</a>
+      </li>
+      <li data-bind="tooltips: {}"><a title="gallery-template" data-local="true" href="#toolimagesgallerytemplate"
+          data-bind="attr: { title: $root.t('gallery-template') }, text: $root.t('gallery-template')">gallery-template</a>
+      </li>
     </ul>
 
     <div id="toolimagesgallery" class="gallery-panel">
-      <!-- ko template: {name: 'gallery-upload', data: { type: 'mailing' } } --># mailing gallery fileupload #<!-- /ko -->
-    <!-- ko if: $root.mailingGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery" href="javascript:void(0)" data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadMailingGallery, button: { disabled: $root.mailingGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.mailingGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }"># load gallery #</a><!-- /ko -->
+      <!-- ko template: {name: 'gallery-upload', data: { type: 'mailing' } } --># mailing gallery fileupload
+      #<!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery"
+        href="javascript:void(0)"
+        data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadMailingGallery, button: { disabled: $root.mailingGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.mailingGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }">#
+        load gallery #</a><!-- /ko -->
 
 
-    <!-- ko if: $root.mailingGalleryStatus() === 'loading' --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading mailing gallery…</div><!-- /ko -->
-    <!-- ko if: $root.mailingGalleryStatus() === 0 --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The mailing gallery is empty</div><!-- /ko -->
-    <!-- ko template: {name: 'gallery-images', data: { items: mailingGallery, type: 'mailing' } } --># mailing gallery #<!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === 'loading' -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading mailing gallery…</div>
+      <!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === 0 -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The mailing gallery is empty</div>
+      <!-- /ko -->
+      <!-- ko template: {name: 'gallery-images', data: { items: mailingGallery, type: 'mailing' } } --># mailing gallery
+      #<!-- /ko -->
     </div>
 
     <div id="toolimagesgallerytemplate" class="gallery-panel">
-      <!-- ko template: {name: 'gallery-upload', data: { type: 'template' } } --># mailing template fileupload #<!-- /ko -->
+      <!-- ko template: {name: 'gallery-upload', data: { type: 'template' } } --># mailing template fileupload
+      #<!-- /ko -->
 
-      <!-- ko if: $root.templateGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery" href="javascript:void(0)" data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadTemplateGallery, button: { disabled: $root.templateGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.templateGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }"># load gallery #</a><!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery"
+        href="javascript:void(0)"
+        data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadTemplateGallery, button: { disabled: $root.templateGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.templateGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }">#
+        load gallery #</a><!-- /ko -->
 
 
-      <!-- ko if: $root.templateGalleryStatus() === 'loading' --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading template gallery...</div><!-- /ko -->
-      <!-- ko if: $root.templateGalleryStatus() === 0 --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The template gallery is empty</div><!-- /ko -->
-      <!-- ko template: {name: 'gallery-images', data: { items: templateGallery, type: 'template' } } --># template gallery #<!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === 'loading' -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading template gallery...</div>
+      <!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === 0 -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The template gallery is empty</div>
+      <!-- /ko -->
+      <!-- ko template: {name: 'gallery-images', data: { items: templateGallery, type: 'template' } } --># template
+      gallery #<!-- /ko -->
     </div>
   </div>
   <!-- /ko -->
@@ -103,9 +169,12 @@
   BlockDefs:
   <pre data-bind='text: ko.toJSON(blockDefs, null, 2)' style="overflow: auto; height: 20%"></pre>
   <!-- /ko -->
-  <a href="javascript:void(0)" data-bind="click: $root.exportHTMLtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Generate' }">Output</a>
-  <a href="javascript:void(0)" data-bind="click: $root.exportJSONtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Export' }">Export</a>
-  <a href="javascript:void(0)" data-bind="click: $root.importJSONfromTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Import' }">Import</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.exportHTMLtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Generate' }">Output</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.exportJSONtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Export' }">Export</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.importJSONfromTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Import' }">Import</a>
 
   <textarea id="outputhtml" rows="10" style="width: 100%;"></textarea>
 </div>
@@ -114,8 +183,8 @@
   <div class="close" data-bind="click: $root.showTheme.bind($element, false);">X</div>
 
   <!-- ko withProperties: { templateMode: 'styler' } -->
-    <!-- ko if: $root.showTheme -->
-      <!-- ko block: $root.content().theme --><!-- /ko -->
-    <!-- /ko -->
+  <!-- ko if: $root.showTheme -->
+  <!-- ko block: $root.content().theme --><!-- /ko -->
+  <!-- /ko -->
   <!-- /ko -->
 </div>

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -25,25 +25,16 @@
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div id="blockTabs" class="tabs_horizontal button_color blocks-tabs"
-      data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <ul>
-        <!-- Tab for Default Blocks -->
-        <li data-bind="tooltips: {}">
-          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }">
-            <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
-          </a>
-        </li>
-
-        <!-- Tab for Personalized Blocks -->
-        <li data-bind="tooltips: {}">
-          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }">
-            <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
-          </a>
-        </li>
-      </ul>
+    <div id="blockTabs" class="custom-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <div class="custom-tab-item" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }, css: { 'custom-tab-active': $root.blocksActiveTab() === 'DEFAULT_BLOCKS' }">
+        <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
+      </div>
+      <div class="custom-tab-item" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }, css: { 'custom-tab-active': $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS' }">
+        <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
+      </div>
     </div>
-    <div id="template-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+    
+    <div id="DEFAULT_BLOCKS" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
       <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
         <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
           <div class="block"
@@ -63,7 +54,7 @@
         </div>
       </div>
     </div>
-    <div id="-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+    <div id="PERSONALIZED_BLOCKS" data-bind="if: $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS'">
       EMPTY LIST
     </div>
   </div>

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -26,15 +26,15 @@
 
   <div id="toolblocks" data-bind="scrollable: true">
     <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'DEFAULT_BLOCKS' }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
         <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
       </div>
-      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS' }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
         <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
       </div>
     </div>
     
-    <div data-bind="visible: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+    <div data-bind="visible: $root.blocksActiveTab() === 'TEMPLATE_BLOCKS'">
       <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
         <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
           <div class="block"
@@ -54,7 +54,7 @@
         </div>
       </div>
     </div>
-    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'PERSONALIZED_BLOCKS'">
+    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
       Coming Soon
     </div>
   </div>

--- a/packages/editor/src/tmpl/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl/toolbox.tmpl.html
@@ -1,19 +1,70 @@
 <div id="tooltabs" class="tabs_horizontal button_color" data-bind="tabs: { active: $root.selectedTool }">
-  <ul>
-    <li data-bind="tooltips: {}"><a title="Blocks ready to be added to the template" data-local="true" href="#toolblocks" data-bind="attr: { title: $root.t('Blocks ready to be added to the template') }"><i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Blocks')">Blocks</span></a></li>
-    <li data-bind="tooltips: {}"><a title="Edit content options" href="#toolcontents" data-local="true" data-bind="attr: { title: $root.t('Edit content options') }"><i class="fa fa-fw fa-pencil"></i> <span data-bind="html: $root.t('Content')">Content</span></a></li>
-    <li data-bind="tooltips: {}"><a title="Edit style options" href="#toolstyles" data-local="true" data-bind="attr: { title: $root.t('Edit style options') }"><i class="fa fa-fw fa-paint-brush"></i> <span data-bind="html: $root.t('Style')">Style</span></a></li>
-  </ul>
+  <!-- VueJs for the esp component-->
+  <div id="espModal">
+    <esp-plugin />
+  </div>
+  <div id="customizedBlockModal">
+    <customized-block-plugin />
+  </div>
+  <div class="tooltabs__top-bar">
+    <a class="tooltabs__top-logo" href="/" data-bind="attr: { href: $root.logoUrl }">
+      <img data-bind="attr: { src: $root.logoPath, alt: $root.logoAlt }" alt="mosaico" />
+    </a>
+    <ul class="tooltabs__list">
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Blocks ready to be added to the template"
+          data-local="true" href="#toolblocks"
+          data-bind="attr: { title: $root.t('Blocks ready to be added to the template') }"><i
+            class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Blocks')">Blocks</span></a></li>
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit content options" href="#toolcontents"
+          data-local="true" data-bind="attr: { title: $root.t('Edit content options') }"><i
+            class="fa fa-fw fa-pencil"></i> <span data-bind="html: $root.t('Content')">Content</span></a></li>
+      <li class="tooltabs__item" data-bind="tooltips: {}"><a title="Edit style options" href="#toolstyles"
+          data-local="true" data-bind="attr: { title: $root.t('Edit style options') }"><i
+            class="fa fa-fw fa-paint-brush"></i> <span data-bind="html: $root.t('Style')">Style</span></a></li>
+    </ul>
+  </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
-      <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
-        <div class="block" data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock" style="position: relative;">
-          <div title="Click or drag to add this block to the template" class="handle" data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}"></div>
-          <img data-bind="attr: { alt: $root.t('Block __name__', { name: ko.utils.unwrapObservable(type) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }" alt="Block __name__" />
+    <div id="blockTabs" class="tabs_horizontal button_color blocks-tabs"
+      data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <ul>
+        <!-- Tab for Default Blocks -->
+        <li data-bind="tooltips: {}">
+          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }">
+            <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
+          </a>
+        </li>
+
+        <!-- Tab for Personalized Blocks -->
+        <li data-bind="tooltips: {}">
+          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }">
+            <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div id="template-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+      <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
+        <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
+          <div class="block"
+            data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock"
+            style="position: relative;">
+            <div title="Click or drag to add this block to the template" class="handle"
+              data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
+            </div>
+            <img
+              data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(type) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
+              alt="__name__" />
+            <span class="block-name"
+              data-bind="html: $root.t('__name__', { name: ko.utils.unwrapObservable(type) })">__name__</span>
+          </div>
+          <a href="javascript:void(0)" class="addblockbutton"
+            data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
         </div>
-        <a href="javascript:void(0)" class="addblockbutton" data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
       </div>
+    </div>
+    <div id="-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+      EMPTY LIST
     </div>
   </div>
 
@@ -22,23 +73,31 @@
     <div data-bind="block: $root.selectedBlock"></div>
     <!-- /ko -->
     <!-- ko if: $root.selectedBlock() == null -->
-    <div class="noSelectedBlock" data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">By clicking on message parts you will select a block and content options, if any, will show here</div>
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
+      By clicking on message parts you will select a block and content options, if any, will show here</div>
     <!-- /ko -->
-    <!-- ko block: content -->
-    <!-- /ko -->
+    <!-- ko block: content -->content<!-- /ko -->
+    <div id="tracking-params">
+      <tracking-params-plugin />
+    </div>
   </div>
 
   <div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
     <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
-      <!-- ko if: $root.selectedBlock() !== null -->
-      <div data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }"></div>
-      <!-- /ko -->
-      <!-- ko if: $root.selectedBlock() == null -->
-      <div class="noSelectedBlock" data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">By clicking on message parts you will select a block and style options, if available, will show here</div>
-      <!-- /ko -->
-      <div class="workGlobalContent">
+    <!-- ko if: $root.selectedBlock() !== null -->
+    <div
+      data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $root.selectedBlock() == null -->
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
+      By clicking on message parts you will select a block and style options, if available, will show here</div>
+    <!-- /ko -->
+    <div class="workGlobalContent">
       <!-- ko block: content --><!-- /ko -->
-      </div>
+    </div>
     <!-- /ko -->
   </div>
 </div>
@@ -50,29 +109,51 @@
   <!-- ko if: $root.showGallery() -->
   <div id="toolimagestab" class="tabs_horizontal" data-bind="tabs: { active: $root.selectedImageTab }">
     <ul>
-      <li data-bind="tooltips: {}"><a title="gallery-mailing" data-local="true" href="#toolimagesgallery" data-bind="attr: { title: $root.t('gallery-mailing') }, text: $root.t('gallery-mailing')">gallery-mailing</a></li>
-      <li data-bind="tooltips: {}"><a title="gallery-template" data-local="true" href="#toolimagesgallerytemplate" data-bind="attr: { title: $root.t('gallery-template') }, text: $root.t('gallery-template')">gallery-template</a></li>
+      <li data-bind="tooltips: {}"><a title="gallery-mailing" data-local="true" href="#toolimagesgallery"
+          data-bind="attr: { title: $root.t('gallery-mailing') }, text: $root.t('gallery-mailing')">gallery-mailing</a>
+      </li>
+      <li data-bind="tooltips: {}"><a title="gallery-template" data-local="true" href="#toolimagesgallerytemplate"
+          data-bind="attr: { title: $root.t('gallery-template') }, text: $root.t('gallery-template')">gallery-template</a>
+      </li>
     </ul>
 
     <div id="toolimagesgallery" class="gallery-panel">
-      <!-- ko template: {name: 'gallery-upload', data: { type: 'mailing' } } --># mailing gallery fileupload #<!-- /ko -->
-    <!-- ko if: $root.mailingGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery" href="javascript:void(0)" data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadMailingGallery, button: { disabled: $root.mailingGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.mailingGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }"># load gallery #</a><!-- /ko -->
+      <!-- ko template: {name: 'gallery-upload', data: { type: 'mailing' } } --># mailing gallery fileupload
+      #<!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery"
+        href="javascript:void(0)"
+        data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadMailingGallery, button: { disabled: $root.mailingGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.mailingGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }">#
+        load gallery #</a><!-- /ko -->
 
 
-    <!-- ko if: $root.mailingGalleryStatus() === 'loading' --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading mailing gallery…</div><!-- /ko -->
-    <!-- ko if: $root.mailingGalleryStatus() === 0 --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The mailing gallery is empty</div><!-- /ko -->
-    <!-- ko template: {name: 'gallery-images', data: { items: mailingGallery, type: 'mailing' } } --># mailing gallery #<!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === 'loading' -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading mailing gallery…</div>
+      <!-- /ko -->
+      <!-- ko if: $root.mailingGalleryStatus() === 0 -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The mailing gallery is empty</div>
+      <!-- /ko -->
+      <!-- ko template: {name: 'gallery-images', data: { items: mailingGallery, type: 'mailing' } } --># mailing gallery
+      #<!-- /ko -->
     </div>
 
     <div id="toolimagesgallerytemplate" class="gallery-panel">
-      <!-- ko template: {name: 'gallery-upload', data: { type: 'template' } } --># mailing template fileupload #<!-- /ko -->
+      <!-- ko template: {name: 'gallery-upload', data: { type: 'template' } } --># mailing template fileupload
+      #<!-- /ko -->
 
-      <!-- ko if: $root.templateGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery" href="javascript:void(0)" data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadTemplateGallery, button: { disabled: $root.templateGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.templateGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }"># load gallery #</a><!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === false --><a class="loadbutton" title="Show images from the gallery"
+        href="javascript:void(0)"
+        data-bind="attr: { title: $root.t('Show images from the gallery') }, click: $root.loadTemplateGallery, button: { disabled: $root.templateGalleryStatus, icons: { primary: 'fa fa-fw fa-picture-o' }, label: $root.templateGalleryStatus() == 'loading' ? $root.t('Loading...') : $root.t('Load gallery'), text: true }">#
+        load gallery #</a><!-- /ko -->
 
 
-      <!-- ko if: $root.templateGalleryStatus() === 'loading' --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading template gallery...</div><!-- /ko -->
-      <!-- ko if: $root.templateGalleryStatus() === 0 --><div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The template gallery is empty</div><!-- /ko -->
-      <!-- ko template: {name: 'gallery-images', data: { items: templateGallery, type: 'template' } } --># template gallery #<!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === 'loading' -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-loading')">Loading template gallery...</div>
+      <!-- /ko -->
+      <!-- ko if: $root.templateGalleryStatus() === 0 -->
+      <div class="galleryEmpty" data-bind="text: $root.t('gallery-mailing-empty')">The template gallery is empty</div>
+      <!-- /ko -->
+      <!-- ko template: {name: 'gallery-images', data: { items: templateGallery, type: 'template' } } --># template
+      gallery #<!-- /ko -->
     </div>
   </div>
   <!-- /ko -->
@@ -88,9 +169,12 @@
   BlockDefs:
   <pre data-bind='text: ko.toJSON(blockDefs, null, 2)' style="overflow: auto; height: 20%"></pre>
   <!-- /ko -->
-  <a href="javascript:void(0)" data-bind="click: $root.exportHTMLtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Generate' }">Output</a>
-  <a href="javascript:void(0)" data-bind="click: $root.exportJSONtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Export' }">Export</a>
-  <a href="javascript:void(0)" data-bind="click: $root.importJSONfromTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Import' }">Import</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.exportHTMLtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Generate' }">Output</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.exportJSONtoTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Export' }">Export</a>
+  <a href="javascript:void(0)"
+    data-bind="click: $root.importJSONfromTextarea.bind($element, '#outputhtml'); clickBubble: false, button: { text: true, label:'Import' }">Import</a>
 
   <textarea id="outputhtml" rows="10" style="width: 100%;"></textarea>
 </div>
@@ -99,8 +183,8 @@
   <div class="close" data-bind="click: $root.showTheme.bind($element, false);">X</div>
 
   <!-- ko withProperties: { templateMode: 'styler' } -->
-    <!-- ko if: $root.showTheme -->
-      <!-- ko block: $root.content().theme --><!-- /ko -->
-    <!-- /ko -->
+  <!-- ko if: $root.showTheme -->
+  <!-- ko block: $root.content().theme --><!-- /ko -->
+  <!-- /ko -->
   <!-- /ko -->
 </div>

--- a/packages/editor/src/tmpl/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl/toolbox.tmpl.html
@@ -25,25 +25,16 @@
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div id="blockTabs" class="tabs_horizontal button_color blocks-tabs"
-      data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <ul>
-        <!-- Tab for Default Blocks -->
-        <li data-bind="tooltips: {}">
-          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('DEFAULT_BLOCKS'); }">
-            <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
-          </a>
-        </li>
-
-        <!-- Tab for Personalized Blocks -->
-        <li data-bind="tooltips: {}">
-          <a href="javascript:void(0)" data-bind="click: function() { $root.blocksActiveTab('PERSONALIZED_BLOCKS'); }">
-            <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
-          </a>
-        </li>
-      </ul>
+    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
+        <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
+      </div>
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
+        <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
+      </div>
     </div>
-    <div id="template-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
+    
+    <div data-bind="visible: $root.blocksActiveTab() === 'TEMPLATE_BLOCKS'">
       <div class="block-list" data-bind="foreach: blockDefs" style="text-align: center">
         <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
           <div class="block"
@@ -63,8 +54,8 @@
         </div>
       </div>
     </div>
-    <div id="-blocks" data-bind="if: $root.blocksActiveTab() === 'DEFAULT_BLOCKS'">
-      EMPTY LIST
+    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
+      Coming Soon
     </div>
   </div>
 

--- a/public/lang/mosaico-en.json
+++ b/public/lang/mosaico-en.json
@@ -68,6 +68,8 @@
   "Delete block": "Delete block",
   "Duplicate block": "Duplicate block",
   "Save block": "Save block",
+  "Template Blocks": "Template Blocks",
+  "Custom Blocks": "Custom Blocks",
   "Switch block variant": "Switch block variant",
   "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.": "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.",
   "Drop here": "Drop here",

--- a/public/lang/mosaico-fr.json
+++ b/public/lang/mosaico-fr.json
@@ -68,6 +68,8 @@
   "Delete block": "Supprimer ce bloc",
   "Duplicate block": "Dupliquer ce bloc",
   "Save block": "Sauvegarder ce bloc",
+  "Template Blocks": "Blocs template",
+  "Custom Blocks": "Blocs perso",
   "Switch block variant": "Changer la version du bloc",
   "Theme Colors,Standard Colors,Web Colors,Theme Colors,Back to Palette,History,No history yet.": "Couleurs de thème, Couleurs standard, Couleurs web, Couleurs de thème, Retour à la palette, Historique, Pas encore d'historique",
   "Drop here": "Déposer ici",


### PR DESCRIPTION
## Feature: Add Tabs for "Blocs par défaut" and "Blocs personnalisés" in the Left Sidebar of LePatron

### Description:
The objective is to introduce tabs for "Blocs par défaut" and "Blocs personnalisés" within the left sidebar. These tabs will be displayed when the "Blocs" button in the page header is selected. Until now, the left sidebar displayed only "Blocs par défaut."

### Implementation Details:

#### Frontend:

1. **Control Active Tab in Left Sidebar**
   - File: `viewmodel.js`
   - Task:
     - Add a variable named `blocksActiveTab` to the ViewModel, which could be either `DEFAULT_BLOCKS` or `PERSONALIZED_BLOCKS`.
     - Add a function named `setActiveBlocksTab` that takes a string parameter to set the active tab.
     - Make "Blocs par défaut" the default active tab by setting `blocksActiveTab` to `DEFAULT_BLOCKS`.
     - Note: These changes in the ViewModel will allow for easier management of the active tab in the HTML.

2. **Update HTML Content for Left Sidebar**
   - File: `toolbox.tmpl.html`
   - Task:
     - The page header contains buttons for "Blocs," "Contenu," and "Styles"; this part will remain unchanged.
     - Add tabs for "Blocs par défaut" and "Blocs personnalisés" within the left sidebar, which is always visible but changes its content based on the selected tab in the page header.
     - Add a new container to display the content for both types of blocks.
     - Implement conditions to control which content is displayed based on the active tab (`blocksActiveTab`).
     - Note: The tabs will only be displayed when the "Blocs" button is selected in the page header.

#### Styling:

3. **Update Styling for New Tabs**
   - File: `style_mosaico_tools.less`
   - Task:
     - Add necessary styles to ensure the new tabs and the new container align with the existing design.
     - This file already contains styles for block display; these will be extended to cover the new elements.

### Acceptance Criteria:

- Tabs for "Blocs par défaut" and "Blocs personnalisés" will appear when the "Blocs" button in the page header is selected, changing the content of the always-visible left sidebar.
- "Blocs par défaut" will be set as the default active tab, controlled by the `blocksActiveTab` variable in the ViewModel.
- The design and layout of the new tabs must align with the existing design.

### Time Estimate:
3 days

### Result

https://github.com/Badsender-com/LePatron.email/assets/80390318/e05ce172-262b-484d-885c-ad70d979733f

