### PR TITLE
Display Custom Blocks Listing in the Second Tab of the Left Sidebar

### DIFF
--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -798,11 +798,22 @@
     color: var(--v-primary-base);
   }
 
-  .coming-soon {
-    font-style: italic;
+  /* CSS for the PersonalizedBlocksListComponent */
+
+  /* Style for the loading state */
+  #personalized-blocks-list .loading-state {
+    text-align: center;
     font-size: 1.2em;
-    color: grey;
-    margin-top: 3rem;
+    color: #888;
+    padding: 20px;
+  }
+
+  /* Style for the empty state */
+  #personalized-blocks-list .empty-state {
+    text-align: center;
+    font-size: 1.2em;
+    color: #aaa;
+    padding: 20px;
   }
 
   .blockType {

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -805,7 +805,7 @@
     text-align: center;
     font-size: 1.2em;
     color: #888;
-    padding: 20px;
+    padding: 1.2em;
   }
 
   /* Style for the empty state */
@@ -813,7 +813,7 @@
     text-align: center;
     font-size: 1.2em;
     color: #aaa;
-    padding: 20px;
+    padding: 1.2em;
   }
 
   .blockType {

--- a/packages/editor/src/js/app.js
+++ b/packages/editor/src/js/app.js
@@ -20,6 +20,7 @@ var inlinerPlugin = require('./ext/inliner.js');
 var localStorageLoader = require('./ext/localstorage.js');
 const espPlugin = require('./vue/espPlugin');
 const customizedBlockPlugin = require('./vue/customizedBlockPlugin');
+const personalizedBlocksPlugin = require('./vue/personalizedBlocksPlugin.js');
 const trackingParamsPlugin = require('./vue/trackingParamsPlugin');
 
 if (typeof ko == 'undefined') throw 'Cannot find knockout.js library!';
@@ -185,6 +186,7 @@ var start = function (
     inlinerPlugin,
     espPlugin,
     customizedBlockPlugin,
+    personalizedBlocksPlugin,
     trackingParamsPlugin,
   ];
   if (typeof customExtensions !== 'undefined')

--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -50,6 +50,7 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
     toggleSaveBlockModal: ko.observable(null),
     // Adding observables to manage "Default Blocks" and "Personalized Blocks" tabs
     blocksActiveTab: ko.observable('TEMPLATE_BLOCKS'), // The name of the active tab ("TEMPLATE_BLOCKS" or "CUSTOM_BLOCKS")
+    personalizedBlocks: ko.observable([])
   };
 
   /**

--- a/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
+++ b/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
@@ -1,0 +1,65 @@
+const Vue = require('vue/dist/vue.common');
+const axios = require('axios');
+const { getPersonalizedBlocks } = require('../../utils/apis');
+
+const PersonalizedBlocksListComponent = Vue.component(
+  'PersonalizedBlocksListComponent',
+  {
+    props: {
+      vm: { type: Object, default: () => ({}) },
+    },
+    data: () => ({
+      personalizedBlocks: [],
+      isLoading: false,
+    }),
+    mounted() {
+      this.fetchPersonalizedBlocks();
+    },
+    methods: {
+      fetchPersonalizedBlocks() {
+        this.isLoading = true;
+        const groupId = this.vm?.metadata?.groupId;
+
+        axios
+          .get(getPersonalizedBlocks(), { params: { groupId } })
+          .then((response) => {
+            this.personalizedBlocks = response.data?.items;
+            this.isLoading = false;
+          })
+          .catch((error) => {
+            this.vm.notifier.error(this.vm.t('fetch-blocks-error'));
+            this.isLoading = false;
+          });
+      },
+    },
+    computed: {
+      imagePath() {
+        return type => {
+          return this.vm.templatePath('edres/' + type + '.png');
+        };
+      },
+    },
+    template: `
+      <div class="block-list" style="text-align: center">
+        <!-- Loading Spinner -->
+        <div v-if="isLoading">
+          <span>Loading...</span>
+        </div>
+        <!-- List of Personalized Blocks -->
+        <div v-else v-for="block in personalizedBlocks" :key="block.id" class="draggable-item">
+          <div class="block" style="position: relative;">
+            <div title="Click or drag to add this block to the template" class="handle"></div>
+            <!-- Add an image for each block, customize the src attribute based on your API data -->
+            <img :alt="block.content.type" :src="imagePath(block.content.type)" />
+            <span class="block-name">{{ block.name }}</span>
+          </div>
+          <div class="addblockbutton">Add</div>
+        </div>
+      </div>
+    `,
+  }
+);
+
+module.exports = {
+  PersonalizedBlocksListComponent,
+};

--- a/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
+++ b/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
@@ -38,7 +38,7 @@ const PersonalizedBlocksListComponent = Vue.component(
               response.data?.items.map(({ content, ...blockInformation }) => ({
                 ...content,
                 blockInformation,
-                id: "" // this is so important because it will be override when the block is added to the mail content
+                id: "" // This line is crucial. The `viewModel.loadDefaultBlocks` function will override this `id` when the block is added to the email content. Without this placeholder, there could be issues when adding personalized blocks in emails.
               }))
             );
             this.isLoading = false;

--- a/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
+++ b/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
@@ -14,11 +14,17 @@ const PersonalizedBlocksListComponent = Vue.component(
     mounted() {
       this.fetchPersonalizedBlocks();
       // Add a global event listener to refresh the list of personalized blocks when a new block is added.
-      window.addEventListener('personalizedBlockAdded', this.fetchPersonalizedBlocks);
+      window.addEventListener(
+        'personalizedBlockAdded',
+        this.fetchPersonalizedBlocks
+      );
     },
     beforeDestroy() {
       // Make sure to remove the listener when the component is destroyed
-      window.removeEventListener('personalizedBlockAdded', this.fetchPersonalizedBlocks);
+      window.removeEventListener(
+        'personalizedBlockAdded',
+        this.fetchPersonalizedBlocks
+      );
     },
     methods: {
       fetchPersonalizedBlocks() {
@@ -32,6 +38,7 @@ const PersonalizedBlocksListComponent = Vue.component(
               response.data?.items.map(({ content, ...blockInformation }) => ({
                 ...content,
                 blockInformation,
+                id: "" // this is so important because it will be override when the block is added to the mail content
               }))
             );
             this.isLoading = false;

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -48,11 +48,13 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
     },
     handleOnSubmit() {
       this.isLoading = true;
+      // remove blockInformation from blockContent to do not save it twice
+      const { blockInformation, ...blockContent } = this.blockContent;
       const payload = {
         name: this.blockName,
         category: this.blockCategory,
         groupId: this.vm?.metadata?.groupId, // Retrieve groupId here
-        content: this.blockContent,
+        content: blockContent,
       };
 
       axios

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -61,6 +61,9 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
           this.vm.notifier.success(this.vm.t('save-block-success'));
           this.isLoading = false;
           this.closeModal();
+          // Dispatch a custom event to signal that a new personalized block has been added, triggering a refresh in the list component.
+          const event = new Event('personalizedBlockAdded');
+          window.dispatchEvent(event);
         })
         .catch(() => {
           this.vm.notifier.error(this.vm.t('save-block-error'));

--- a/packages/editor/src/js/vue/personalizedBlocksPlugin.js
+++ b/packages/editor/src/js/vue/personalizedBlocksPlugin.js
@@ -6,8 +6,6 @@ const {
 module.exports = {
   viewModel(vm, ko) {},
   init(vm) {
-    // Init VueJS component
-
     Vue.component('PersonalizedBlocksPlugin', {
       components: {
         PersonalizedBlocksListComponent,

--- a/packages/editor/src/js/vue/personalizedBlocksPlugin.js
+++ b/packages/editor/src/js/vue/personalizedBlocksPlugin.js
@@ -1,0 +1,27 @@
+const Vue = require('vue/dist/vue.common');
+const {
+  PersonalizedBlocksListComponent,
+} = require('./components/personalized-blocks-list/personalized-blocks-list-component');
+
+module.exports = {
+  viewModel(vm, ko) {},
+  init(vm) {
+    // Init VueJS component
+
+    Vue.component('PersonalizedBlocksPlugin', {
+      components: {
+        PersonalizedBlocksListComponent,
+      },
+      data: () => ({
+        viewModel: vm,
+      }),
+      template: `
+        <div>
+          <personalized-blocks-list-component :vm="viewModel"></personalized-blocks-list-component>
+        </div>
+      `,
+    });
+
+    new Vue({ el: '#personalizedBlocksPlugin' });
+  },
+};

--- a/packages/editor/src/js/vue/utils/apis.js
+++ b/packages/editor/src/js/vue/utils/apis.js
@@ -24,6 +24,10 @@ function createPersonalizedBlock() {
   return `${prefixApi}/personalized-blocks`;
 }
 
+function getPersonalizedBlocks() {
+  return `${prefixApi}/personalized-blocks`;
+}
+
 module.exports = {
   getEspIds,
   getProfileDetail,
@@ -31,4 +35,5 @@ module.exports = {
   getEmailGroups,
   sendTestEmails,
   createPersonalizedBlock,
+  getPersonalizedBlocks,
 };

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -30,6 +30,7 @@
     </div>
   </div>
 
+
   <div id="toolcontents" data-bind="scrollable: true">
     <!-- ko if: $root.selectedBlock() !== null -->
     <div data-bind="block: $root.selectedBlock"></div>

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -54,11 +54,13 @@
         </div>
       </div>
     </div>
-    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
-      Coming Soon
+    <div data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
+      <!-- Add the Vue.js component here -->
+      <div id="personalizedBlocksPlugin">
+        <personalized-blocks-plugin />
+      </div>
     </div>
   </div>
-
 
   <div id="toolcontents" data-bind="scrollable: true">
     <!-- ko if: $root.selectedBlock() !== null -->

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -54,12 +54,31 @@
         </div>
       </div>
     </div>
-    <div data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
+    <div class="block-list" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
       <!-- Add the Vue.js component here -->
       <div id="personalizedBlocksPlugin">
         <personalized-blocks-plugin />
       </div>
+      <div data-bind="visible: personalizedBlocks().length > 0, foreach: personalizedBlocks()" style="text-align: center">
+        <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
+          <div class="block"
+            data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock"
+            style="position: relative;">
+            <div title="Click or drag to add this block to the template" class="handle"
+              data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
+            </div>
+            <img 
+              data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
+              alt="__name__" />
+            <span class="block-name"
+              data-bind="html: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) })">__name__</span>
+          </div>
+          <a href="javascript:void(0)" class="addblockbutton"
+            data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
+        </div>
+      </div>
     </div>
+    
   </div>
 
   <div id="toolcontents" data-bind="scrollable: true">

--- a/packages/editor/src/tmpl/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl/toolbox.tmpl.html
@@ -25,14 +25,11 @@
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs"
-      data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <div class="blocks-tab-item"
-        data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
+    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
         <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
       </div>
-      <div class="blocks-tab-item"
-        data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
+      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
         <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
       </div>
     </div>
@@ -57,47 +54,65 @@
         </div>
       </div>
     </div>
-    <div data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
+    <div class="block-list" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
       <!-- Add the Vue.js component here -->
       <div id="personalizedBlocksPlugin">
         <personalized-blocks-plugin />
       </div>
+      <div data-bind="visible: personalizedBlocks().length > 0, foreach: personalizedBlocks()" style="text-align: center">
+        <div class="draggable-item" data-bind="withProperties: { templateMode: 'show' }">
+          <div class="block"
+            data-bind="extdraggable: { connectClass: 'sortable-blocks-edit', data: $data, dropContainer: '#main-wysiwyg-area', dragging: $root.dragging, 'options': { handle: '.handle', distance: 10, 'appendTo': '#page' } }, click: $root.addBlock"
+            style="position: relative;">
+            <div title="Click or drag to add this block to the template" class="handle"
+              data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
+            </div>
+            <img 
+              data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
+              alt="__name__" />
+            <span class="block-name"
+              data-bind="html: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) })">__name__</span>
+          </div>
+          <a href="javascript:void(0)" class="addblockbutton"
+            data-bind="click: $root.addBlock, button: { label: $root.t('Add') }">Add</a>
+        </div>
+      </div>
+    </div>
+    
+  </div>
+
+  <div id="toolcontents" data-bind="scrollable: true">
+    <!-- ko if: $root.selectedBlock() !== null -->
+    <div data-bind="block: $root.selectedBlock"></div>
+    <!-- /ko -->
+    <!-- ko if: $root.selectedBlock() == null -->
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
+      By clicking on message parts you will select a block and content options, if any, will show here</div>
+    <!-- /ko -->
+    <!-- ko block: content -->content<!-- /ko -->
+    <div id="tracking-params">
+      <tracking-params-plugin />
     </div>
   </div>
-</div>
 
-<div id="toolcontents" data-bind="scrollable: true">
-  <!-- ko if: $root.selectedBlock() !== null -->
-  <div data-bind="block: $root.selectedBlock"></div>
-  <!-- /ko -->
-  <!-- ko if: $root.selectedBlock() == null -->
-  <div class="noSelectedBlock"
-    data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
-    By clicking on message parts you will select a block and content options, if any, will show here</div>
-  <!-- /ko -->
-  <!-- ko block: content -->content<!-- /ko -->
-  <div id="tracking-params">
-    <tracking-params-plugin />
+  <div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
+    <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
+    <!-- ko if: $root.selectedBlock() !== null -->
+    <div
+      data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
+    </div>
+    <!-- /ko -->
+    <!-- ko if: $root.selectedBlock() == null -->
+    <div class="noSelectedBlock"
+      data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
+      By clicking on message parts you will select a block and style options, if available, will show here</div>
+    <!-- /ko -->
+    <div class="workGlobalContent">
+      <!-- ko block: content --><!-- /ko -->
+    </div>
+    <!-- /ko -->
   </div>
-</div>
-
-<div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
-  <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
-  <!-- ko if: $root.selectedBlock() !== null -->
-  <div
-    data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
-  </div>
-  <!-- /ko -->
-  <!-- ko if: $root.selectedBlock() == null -->
-  <div class="noSelectedBlock"
-    data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
-    By clicking on message parts you will select a block and style options, if available, will show here</div>
-  <!-- /ko -->
-  <div class="workGlobalContent">
-    <!-- ko block: content --><!-- /ko -->
-  </div>
-  <!-- /ko -->
-</div>
 </div>
 
 <div id="toolimages" class="slidebar" data-bind="scrollable: true, css: { hidden: $root.showGallery() === false }">

--- a/packages/editor/src/tmpl/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl/toolbox.tmpl.html
@@ -25,11 +25,14 @@
   </div>
 
   <div id="toolblocks" data-bind="scrollable: true">
-    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs" data-bind="tabs: { active: $root.blocksActiveTab() }">
-      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
+    <div id="blockTabs" class="blocks-tabs-horizontal button_color blocks-tabs"
+      data-bind="tabs: { active: $root.blocksActiveTab() }">
+      <div class="blocks-tab-item"
+        data-bind="click: function() { $root.blocksActiveTab('TEMPLATE_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'TEMPLATE_BLOCKS' }">
         <i class="fa fa-fw fa-cubes"></i> <span data-bind="html: $root.t('Template Blocks')">Template Blocks</span>
       </div>
-      <div class="blocks-tab-item" data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
+      <div class="blocks-tab-item"
+        data-bind="click: function() { $root.blocksActiveTab('CUSTOM_BLOCKS'); }, css: { 'blocks-tab-active': $root.blocksActiveTab() === 'CUSTOM_BLOCKS' }">
         <i class="fa fa-fw fa-user"></i> <span data-bind="html: $root.t('Custom Blocks')">Custom Blocks</span>
       </div>
     </div>
@@ -54,43 +57,47 @@
         </div>
       </div>
     </div>
-    <div class="coming-soon" data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
-      Coming Soon
+    <div data-bind="visible: $root.blocksActiveTab() === 'CUSTOM_BLOCKS'">
+      <!-- Add the Vue.js component here -->
+      <div id="personalizedBlocksPlugin">
+        <personalized-blocks-plugin />
+      </div>
     </div>
   </div>
+</div>
 
-  <div id="toolcontents" data-bind="scrollable: true">
-    <!-- ko if: $root.selectedBlock() !== null -->
-    <div data-bind="block: $root.selectedBlock"></div>
-    <!-- /ko -->
-    <!-- ko if: $root.selectedBlock() == null -->
-    <div class="noSelectedBlock"
-      data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
-      By clicking on message parts you will select a block and content options, if any, will show here</div>
-    <!-- /ko -->
-    <!-- ko block: content -->content<!-- /ko -->
-    <div id="tracking-params">
-      <tracking-params-plugin />
-    </div>
+<div id="toolcontents" data-bind="scrollable: true">
+  <!-- ko if: $root.selectedBlock() !== null -->
+  <div data-bind="block: $root.selectedBlock"></div>
+  <!-- /ko -->
+  <!-- ko if: $root.selectedBlock() == null -->
+  <div class="noSelectedBlock"
+    data-bind="text: $root.t('By clicking on message parts you will select a block and content options, if any, will show here')">
+    By clicking on message parts you will select a block and content options, if any, will show here</div>
+  <!-- /ko -->
+  <!-- ko block: content -->content<!-- /ko -->
+  <div id="tracking-params">
+    <tracking-params-plugin />
   </div>
+</div>
 
-  <div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
-    <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
-    <!-- ko if: $root.selectedBlock() !== null -->
-    <div
-      data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
-    </div>
-    <!-- /ko -->
-    <!-- ko if: $root.selectedBlock() == null -->
-    <div class="noSelectedBlock"
-      data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
-      By clicking on message parts you will select a block and style options, if available, will show here</div>
-    <!-- /ko -->
-    <div class="workGlobalContent">
-      <!-- ko block: content --><!-- /ko -->
-    </div>
-    <!-- /ko -->
+<div id="toolstyles" data-bind="scrollable: true, withProperties: { templateMode: 'styler' }">
+  <!-- ko if: typeof $root.content().theme === 'undefined' || typeof $root.content().theme().scheme === 'undefined' || $root.content().theme().scheme() === 'custom' -->
+  <!-- ko if: $root.selectedBlock() !== null -->
+  <div
+    data-bind="block: $root.selectedBlock, css: { workLocal: $root.selectedBlock().customStyle, workGlobal: typeof $root.selectedBlock().customStyle === 'undefined' || !$root.selectedBlock().customStyle() }">
   </div>
+  <!-- /ko -->
+  <!-- ko if: $root.selectedBlock() == null -->
+  <div class="noSelectedBlock"
+    data-bind="text: $root.t('By clicking on message parts you will select a block and style options, if available, will show here')">
+    By clicking on message parts you will select a block and style options, if available, will show here</div>
+  <!-- /ko -->
+  <div class="workGlobalContent">
+    <!-- ko block: content --><!-- /ko -->
+  </div>
+  <!-- /ko -->
+</div>
 </div>
 
 <div id="toolimages" class="slidebar" data-bind="scrollable: true, css: { hidden: $root.showGallery() === false }">

--- a/packages/server/group/group.guard.js
+++ b/packages/server/group/group.guard.js
@@ -41,7 +41,29 @@ const guardCanAccessGroupFromBody = () => {
   };
 };
 
+const guardCanAccessGroupFromQuery = () => {
+  return (req, res, next) => {
+    const { user } = req;
+    if (!user) {
+      return next(new createError.Unauthorized());
+    }
+
+    // We bypass the check if the user is a super admin
+    if (user.isAdmin) {
+      return next();
+    }
+    const { groupId } = req.query; // Get groupId from the request query
+    const { group } = user;
+
+    if (group.id === groupId) {
+      return next();
+    }
+    next(new createError.Unauthorized());
+  };
+};
+
 module.exports = {
   GUARD_CAN_ACCESS_GROUP: guardCanAccessGroup(),
   GUARD_CAN_ACCESS_GROUP_FROM_BODY: guardCanAccessGroupFromBody(),
+  GUARD_CAN_ACCESS_GROUP_FROM_QUERY: guardCanAccessGroupFromQuery(),
 };

--- a/packages/server/personalized-blocks/personalized-block-controller.js
+++ b/packages/server/personalized-blocks/personalized-block-controller.js
@@ -22,7 +22,7 @@ module.exports = {
  * @apiSuccess {personalizedBlock[]} items list of personalized blocks
  */
 async function listPersonalizedBlocks(req, res, next) {
-  const { groupId } = req.body;
+  const { groupId } = req.query;
   if (!groupId) {
     return next(new createHttpError.BadRequest(ERROR_CODES.GROUP_ID_REQUIRED));
   }

--- a/packages/server/personalized-blocks/personalized-block-routes.js
+++ b/packages/server/personalized-blocks/personalized-block-routes.js
@@ -2,7 +2,10 @@
 
 const express = require('express');
 const { guard } = require('../account/auth.guard.js');
-const { GUARD_CAN_ACCESS_GROUP_FROM_BODY } = require('../group/group.guard.js');
+const {
+  GUARD_CAN_ACCESS_GROUP_FROM_BODY,
+  GUARD_CAN_ACCESS_GROUP_FROM_QUERY,
+} = require('../group/group.guard.js');
 const createError = require('http-errors');
 
 const router = express.Router();
@@ -13,7 +16,7 @@ const personalizedBlocksController = require('./personalized-block-controller.js
 router.get(
   '/',
   guard(),
-  GUARD_CAN_ACCESS_GROUP_FROM_BODY,
+  GUARD_CAN_ACCESS_GROUP_FROM_QUERY,
   personalizedBlocksController.listPersonalizedBlocks
 );
 

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -112,7 +112,7 @@ module.exports = {
 
   // PersonalizedBlocksListComponent translations
   'personalized-blocks-fetch-error':
-    'An error occurred while fetching Custom blocks.',
+    'An error occurred while fetching custom blocks.',
   'personalized-blocks-loading': 'Loading custom blocks...',
   'personalized-blocks-empty': 'No custom blocks available.',
 };

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -109,4 +109,10 @@ module.exports = {
   'saving-block': 'Saving block',
   'save-block-success': 'Block saved successfully',
   'save-block-error': 'Error saving block',
+
+  // PersonalizedBlocksListComponent translations
+  'personalized-blocks-fetch-error':
+    'An error occurred while fetching Custom blocks.',
+  'personalized-blocks-loading': 'Loading custom blocks...',
+  'personalized-blocks-empty': 'No custom blocks available.',
 };

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -113,7 +113,7 @@ module.exports = {
 
   // PersonalizedBlocksListComponent translations
   'personalized-blocks-fetch-error':
-    "Une erreur s'est produite lors de la récupération des Blocs perso.",
+    "Une erreur s'est produite lors de la récupération des blocs perso.",
   'personalized-blocks-loading': 'Chargement des blocs perso...',
   'personalized-blocks-empty': 'Aucun bloc perso disponible.',
 };

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -110,4 +110,10 @@ module.exports = {
   'saving-block': 'Enregistrement en cours',
   'save-block-success': 'Bloc enregistré avec succès',
   'save-block-error': "Erreur lors de l'enregistrement du bloc",
+
+  // PersonalizedBlocksListComponent translations
+  'personalized-blocks-fetch-error':
+    "Une erreur s'est produite lors de la récupération des Blocs perso.",
+  'personalized-blocks-loading': 'Chargement des blocs perso...',
+  'personalized-blocks-empty': 'Aucun bloc perso disponible.',
 };


### PR DESCRIPTION
### Feature: Display Personalized Blocks Listing in the Second Tab of the Left Sidebar

#### Description:
Integrate the listing of Personalized Blocks in the existing second tab in the left sidebar when the "Blocks" button in the page header is selected.

#### Implementation Details:

#### Frontend:

1. **Initialize Main Vue.js Component `PersonalizedBlocksPlugin`**
   - File: `personalizedBlocksPlugin.js`
   - Task:
     - Create a Vue.js component to configure the ViewModel and extensions. Use `this.vm.` to refer to the ViewModel.
   - Example Template:
     ```javascript
     Vue.component('PersonalizedBlocksPlugin', {
       components: {
         PersonalizedBlocksListComponent,
       },
       data: () => ({
         viewModel: vm,
       }),
       //... other logic
     });
     ```

2. **Initialize List Component `PersonalizedBlocksListComponent`**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - Create a Vue.js component to manage the listing of Personalized Blocks, including API calls, loading state, and error handling.
   - Example Template:
     ```javascript
     Vue.component('PersonalizedBlocksListComponent', {
       //... other logic
     });
     ```

3. **API Calls to Fetch Personalized Blocks**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - Add a method named `fetchPersonalizedBlocks` that will make an API call to the `getPersonalizedBlocks` endpoint. Utilize `this.vm.metadata.groupId` for the `groupId`.

4. **Manage Loading State**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - Add a Vue.js data property `isLoading` to manage the loading state. Display a loading spinner while fetching data.

5. **Vue Data Property for Personalized Blocks**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - Add a Vue.js data property named `personalizedBlocks` to store the fetched blocks.

6. **Displaying Personalized Blocks Using Existing HTML Structure**
   - File: `toolbox.tmpl.html`
   - Task:
     - Utilize the HTML structure already in place for displaying template blocks. Bind this part to the `personalizedBlocks` data property from the Vue component.

7. **Handle Errors**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - In case of an API failure, display an error toast notification using `this.vm.notifier.error(message)`.

8. **Integrate the Vue.js Component into HTML**
   - File: `toolbox.tmpl.html`
   - Task:
     - Add a tag `<personalized-blocks-list-component />` to integrate the Vue.js component within the HTML file.

#### Acceptance Criteria:

- The second tab in the left sidebar successfully displays the list of Personalized Blocks when `blocksActiveTab` is set to `CUSTOM_BLOCKS`.
- The HTML structure for displaying Personalized Blocks is the same as that for displaying template blocks.
- A loading spinner is displayed while fetching data.
- Toast notifications are displayed in case of API errors.

#### Time Estimate:
2-3 days

## RESULT

https://github.com/Badsender-com/LePatron.email/assets/80390318/a22a8e47-ca23-4155-98ab-771b36dd6b8a
