### PR TITLE
Feat add filtering custom blocks

### DIFF
--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -740,6 +740,38 @@
     }
   }
 
+  .input-field.search-container {
+    position: relative;
+    margin-bottom: 1rem;
+
+    .search-input {
+      width: 100%;
+      height: 2.3rem;
+      border: 2px solid #ccc; // Border color when not focused
+      border-radius: 4px; // Rounded corners
+      padding: 4px 8px; // Some padding for better appearance
+      transition: border-color 0.3s ease; // Transition effect for smooth change
+
+      &:focus {
+        border-width: 2px;
+        border-color: #26a69a; // Border color when focused
+        outline: none; // Remove default outline
+      }
+    }
+
+    label {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+
+    .search-icon {
+      cursor: pointer;
+    }
+  }
+
   .buttons-container {
     display: flex;
     flex-direction: row;
@@ -833,6 +865,14 @@
     text-align: center;
     font-size: 1.2em;
     color: #aaa;
+    padding: 1.2em;
+  }
+
+  /* Style for the search empty state */
+  #personalized-blocks-list .empty-state-search {
+    text-align: center;
+    font-size: 1.2em;
+    color: gray;
     padding: 1.2em;
   }
 

--- a/packages/editor/src/css/style_mosaico_tools.less
+++ b/packages/editor/src/css/style_mosaico_tools.less
@@ -749,7 +749,7 @@
       height: 2.3rem;
       border: 2px solid #ccc; // Border color when not focused
       border-radius: 4px; // Rounded corners
-      padding: 4px 8px; // Some padding for better appearance
+      padding: 0.25rem 0.5rem; // Some padding for better appearance
       transition: border-color 0.3s ease; // Transition effect for smooth change
 
       &:focus {
@@ -761,7 +761,7 @@
 
     label {
       position: absolute;
-      right: 8px;
+      right: 0.5rem;
       top: 50%;
       transform: translateY(-50%);
       cursor: pointer;
@@ -857,7 +857,7 @@
     text-align: center;
     font-size: 1.2em;
     color: #888;
-    padding: 1.2em;
+    padding: 1rem;
   }
 
   /* Style for the empty state */
@@ -865,7 +865,7 @@
     text-align: center;
     font-size: 1.2em;
     color: #aaa;
-    padding: 1.2em;
+    padding: 1rem;
   }
 
   /* Style for the search empty state */
@@ -873,7 +873,7 @@
     text-align: center;
     font-size: 1.2em;
     color: gray;
-    padding: 1.2em;
+    padding: 1rem;
   }
 
   .blockType {

--- a/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
+++ b/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
@@ -1,6 +1,8 @@
 const Vue = require('vue/dist/vue.common');
 const axios = require('axios');
 const { getPersonalizedBlocks } = require('../../utils/apis');
+const debounce = require('lodash.debounce');
+const DEBOUNCE_DELAY_MS = 400;
 
 const PersonalizedBlocksListComponent = Vue.component(
   'PersonalizedBlocksListComponent',
@@ -10,9 +12,15 @@ const PersonalizedBlocksListComponent = Vue.component(
     },
     data: () => ({
       isLoading: false,
+      searchTerm: '',
     }),
     mounted() {
       this.fetchPersonalizedBlocks();
+      // Initialize debounced function
+      this.debouncedFetch = debounce(
+        this.fetchPersonalizedBlocks,
+        DEBOUNCE_DELAY_MS
+      );
       // Add a global event listener to refresh the list of personalized blocks when a new block is added.
       window.addEventListener(
         'personalizedBlockApiActionApplied',
@@ -29,16 +37,19 @@ const PersonalizedBlocksListComponent = Vue.component(
     methods: {
       fetchPersonalizedBlocks() {
         this.isLoading = true;
+        this.vm.personalizedBlocks([]);
         const groupId = this.vm?.metadata?.groupId;
 
         axios
-          .get(getPersonalizedBlocks(), { params: { groupId } })
+          .get(getPersonalizedBlocks(), {
+            params: { groupId, searchTerm: this.searchTerm },
+          })
           .then((response) => {
             this.vm.personalizedBlocks(
               response.data?.items.map(({ content, ...blockInformation }) => ({
                 ...content,
                 blockInformation,
-                id: "" // This line is crucial. The `viewModel.loadDefaultBlocks` function will override this `id` when the block is added to the email content. Without this placeholder, there could be issues when adding personalized blocks in emails.
+                id: '',
               }))
             );
             this.isLoading = false;
@@ -53,12 +64,26 @@ const PersonalizedBlocksListComponent = Vue.component(
     },
     template: `
     <div id="personalized-blocks-list">
+      <!-- Input field with style and search icon -->
+      <div class="input-field search-container">
+        <input type="text" 
+         v-model="searchTerm" 
+         @input="debouncedFetch" 
+         :placeholder="vm.t('personalized-blocks-search-placeholder')" 
+         class="search-input"
+         id="searchBlock"/>
+        <label for="searchBlock"><i class="fa fa-search search-icon"></i></label> <!-- Search Icon -->
+      </div>
       <div v-if="isLoading" class="loading-state">
         <!-- Loading Spinner -->
         <span>{{ vm.t('personalized-blocks-loading') }}</span>
       </div>
+      <div v-else-if="vm.personalizedBlocks().length === 0 && searchTerm" class="empty-state-search">
+        <!-- Empty Search State -->
+        <span>{{ vm.t('personalized-blocks-empty-search') }}</span>
+      </div>
       <div v-else-if="vm.personalizedBlocks().length === 0" class="empty-state">
-        <!-- Empty State -->
+        <!-- General Empty State -->
         <span>{{ vm.t('personalized-blocks-empty') }}</span>
       </div>
     </div>

--- a/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
+++ b/packages/editor/src/js/vue/components/personalized-blocks-list/personalized-blocks-list-component.js
@@ -2,7 +2,7 @@ const Vue = require('vue/dist/vue.common');
 const axios = require('axios');
 const { getPersonalizedBlocks } = require('../../utils/apis');
 const debounce = require('lodash.debounce');
-const DEBOUNCE_DELAY_MS = 400;
+const { INPUT_DEBOUNCE_DELAY_MS } = require('../../constant/blocks');
 
 const PersonalizedBlocksListComponent = Vue.component(
   'PersonalizedBlocksListComponent',
@@ -19,7 +19,7 @@ const PersonalizedBlocksListComponent = Vue.component(
       // Initialize debounced function
       this.debouncedFetch = debounce(
         this.fetchPersonalizedBlocks,
-        DEBOUNCE_DELAY_MS
+        INPUT_DEBOUNCE_DELAY_MS
       );
       // Add a global event listener to refresh the list of personalized blocks when a new block is added.
       window.addEventListener(
@@ -49,7 +49,7 @@ const PersonalizedBlocksListComponent = Vue.component(
               response.data?.items.map(({ content, ...blockInformation }) => ({
                 ...content,
                 blockInformation,
-                id: '',
+                id: '', // This line is crucial. The `viewModel.loadDefaultBlocks` function will override this `id` when the block is added to the email content. Without this placeholder, there could be issues when adding personalized blocks in emails.
               }))
             );
             this.isLoading = false;

--- a/packages/editor/src/js/vue/constant/blocks.js
+++ b/packages/editor/src/js/vue/constant/blocks.js
@@ -1,0 +1,5 @@
+const INPUT_DEBOUNCE_DELAY_MS = 400;
+
+module.exports = {
+  INPUT_DEBOUNCE_DELAY_MS,
+};

--- a/packages/server/personalized-blocks/personalized-block-controller.js
+++ b/packages/server/personalized-blocks/personalized-block-controller.js
@@ -22,14 +22,14 @@ module.exports = {
  * @apiSuccess {personalizedBlock[]} items list of personalized blocks
  */
 async function listPersonalizedBlocks(req, res, next) {
-  const { groupId } = req.query;
+  const { groupId, searchTerm } = req.query;
   if (!groupId) {
     return next(new createHttpError.BadRequest(ERROR_CODES.GROUP_ID_REQUIRED));
   }
 
-  // Fetching personalized blocks sorted by creation date (newest last)
   const personalizedBlocks = await personalizedBlockService.getPersonalizedBlocks(
-    groupId
+    groupId,
+    searchTerm
   );
   return res.json({ items: personalizedBlocks });
 }

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -117,6 +117,8 @@ module.exports = {
     'An error occurred while fetching custom blocks.',
   'personalized-blocks-loading': 'Loading custom blocks...',
   'personalized-blocks-empty': 'No custom blocks available.',
+  'personalized-blocks-empty-search': 'No results found for your search.',
+  'personalized-blocks-search-placeholder': 'Search...',
 
   // DeleteBlockModal translations
   'title-delete-block': 'Delete block',

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -118,6 +118,9 @@ module.exports = {
     "Une erreur s'est produite lors de la récupération des blocs personnalisés.",
   'personalized-blocks-loading': 'Chargement des blocs personnalisés...',
   'personalized-blocks-empty': 'Aucun bloc personnalisé disponible.',
+  'personalized-blocks-empty-search':
+    'Aucun résultat trouvé pour votre recherche.',
+  'personalized-blocks-search-placeholder': 'Rechercher...',
 
   // DeleteBlockModal translations
   'title-delete-block': 'Supprimer le bloc',


### PR DESCRIPTION
### Feature: Full-Text Search in Custom Block Library

#### Description
The aim is to introduce a full-text search functionality within the custom block library. The search will allow filtering of blocks based on their name, category, and the username of the person who created them.

#### Implementation Details

#### Backend:

1. **Extend API for Custom Blocks Search**
   - File: `personalized-block-service.js`
   - Task:
     - Add a query parameter `searchTerm` in the `getPersonalizedBlocks` method.
     - Implement logic to filter blocks based on the `searchTerm` against block names, categories, and usernames.
     - Note: The username is not directly stored in the `personalizedBlock` collection. A join-like operation (e.g., MongoDB `$lookup`) will be used to fetch the username from the users collection for filtering.

#### Frontend:

2. **Integrate Full-Text Search Logic in Vue Component**
   - File: `personalizedBlocksListComponent.js`
   - Task:
     - Add a data property `searchTerm` to hold the text entered by the user.
     - Add a method `handleSearch` to update `searchTerm` and call `fetchPersonalizedBlocks` with the `searchTerm` as a parameter.
     - Handle empty states: Display a "No results found" message if the search yields no blocks. If `searchTerm` is empty, display a general empty state message.

3. **Automatically Update Displayed Blocks**
   - File: `toolbox.tmpl.html`
   - Task:
     - The `personalizedBlocks` data property will automatically update based on the filtered results from `personalizedBlocksListComponent.js`. No additional logic is required in this file for displaying filtered results.

#### Acceptance Criteria:

- A full-text search field is integrated within `personalizedBlocksListComponent.js`.
- Blocks can be filtered by the `searchTerm`, which checks against block names, categories, and usernames.
- Empty state messages are handled gracefully, with specific messaging for a general empty state and when a `searchTerm` yields no results.

#### Time Estimate:
1 or 2 days

### RESULT

https://github.com/Badsender-com/LePatron.email/assets/80390318/4528d25f-7263-4272-a5c3-ccda5efbe83f


