### PR TITLE
Feature: Filter Personalized Blocks by Template Origin Using Mailing ID

### DIFF
--- a/packages/editor/src/css/badsender-main-toolbox.less
+++ b/packages/editor/src/css/badsender-main-toolbox.less
@@ -17,6 +17,26 @@
     width: ~'calc(100% + 40px)';
   }
 
+  .block-image {
+    min-height: 6rem;
+    min-width: 100%;
+    box-shadow: 0 0 1px #808080;
+    display: inline-block;
+    vertical-align: middle;
+    text-align: center;
+    line-height: 6rem; /* same value as min-height */
+    background: #ffffffde;
+  }
+
+  .block-image::before {
+    content: "\f1c5"; // Unicode for icon "fa-file-image" */
+    margin-right: 0.3rem;
+    margin-top: -0.1rem;
+    font-family: FontAwesome;
+    display: inline-block;
+    vertical-align: middle;
+  }
+
   .draggable-item {
     margin-left: @gallery-gutter;
     margin-right: @gallery-gutter;

--- a/packages/editor/src/js/ext/badsender-current-mailing.js
+++ b/packages/editor/src/js/ext/badsender-current-mailing.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+
+module.exports = (opts) => {
+  // Retrieve the current mailing ID from the metadata
+  const currentMailingId = opts.metadata.id;
+
+  function viewModel(viewModel) {
+    // Initialize an observable for the current mailing information
+    viewModel.currentMailing = ko.observable(null);
+
+    // API call to get detailed information about the current mailing
+    axios
+      .get(`/api/mailings/${currentMailingId}`)
+      .then((response) => {
+        const detailedMailInfo = response.data;
+        viewModel.currentMailing(detailedMailInfo);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }
+
+  return {
+    viewModel,
+  };
+};

--- a/packages/editor/src/js/ext/badsender-extensions.js
+++ b/packages/editor/src/js/ext/badsender-extensions.js
@@ -22,6 +22,7 @@ const extendTextEditor = require('./badsender-extend-text-editor');
 const colorPicker = require('./badsender-color-picker');
 const personalizedVariables = require('./badsender-personalized-variables.js');
 const currentUser = require('./badsender-current-user.js');
+const currentMailing = require('./badsender-current-mailing.js');
 const selectItem = require('./badsender-select-item.js');
 const screenPreview = require('./badsender-screen-preview.js');
 
@@ -62,6 +63,7 @@ function extendViewModel(opts, customExtensions) {
   customExtensions.push(colorPicker(opts));
   customExtensions.push(personalizedVariables(opts));
   customExtensions.push(currentUser(opts));
+  customExtensions.push(currentMailing(opts));
   customExtensions.push(espProfiles(opts));
   customExtensions.push(removeImage);
   customExtensions.push(configExtendTinyMce(opts));

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -60,6 +60,9 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
       this.isLoading = true;
       let payload = {};
       let blockId = null;
+
+      const templateId = this.vm?.currentMailing?.templateId; // Retrieve templateId from currentMailing
+
       // Construct the payload based on the mode
       if (this.mode === 'CREATE') {
         const { blockInformation, ...blockContent } = this.blockContent;
@@ -68,6 +71,7 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
           category: this.blockCategory,
           groupId: this.vm?.metadata?.groupId,
           content: blockContent,
+          templateId, // Include templateId in payload only for CREATE mode
         };
       } else if (this.mode === 'EDIT') {
         const { blockInformation } = this.blockContent;

--- a/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
+++ b/packages/editor/src/js/vue/components/save-block-modal/save-modal.js
@@ -61,7 +61,7 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
       let payload = {};
       let blockId = null;
 
-      const templateId = this.vm?.currentMailing?.templateId; // Retrieve templateId from currentMailing
+      const templateId = this.vm?.currentMailing()?.templateId; // Retrieve templateId from currentMailing
 
       // Construct the payload based on the mode
       if (this.mode === 'CREATE') {
@@ -75,7 +75,7 @@ const SaveBlockModalComponent = Vue.component('SaveBlockModal', {
         };
       } else if (this.mode === 'EDIT') {
         const { blockInformation } = this.blockContent;
-        blockId = blockInformation.id; // Use the ID for editing
+        blockId = blockInformation._id; // Use the ID for editing
         payload = {
           name: this.blockName,
           category: this.blockCategory,

--- a/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl-badsender/toolbox.tmpl.html
@@ -73,6 +73,7 @@
               data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
             </div>
             <img
+              class="block-image"
               data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
               alt="__name__" />
             <span class="block-name"

--- a/packages/editor/src/tmpl/toolbox.tmpl.html
+++ b/packages/editor/src/tmpl/toolbox.tmpl.html
@@ -73,6 +73,7 @@
               data-bind="attr: { title: $root.t('Click or drag to add this block to the template') }, tooltips: {}">
             </div>
             <img
+              class="block-image"
               data-bind="attr: { alt: $root.t('__name__', { name: ko.utils.unwrapObservable(blockInformation.name) }), src: $root.templatePath('edres/'+ko.utils.unwrapObservable(type)+'.png') }"
               alt="__name__" />
             <span class="block-name"

--- a/packages/server/personalized-blocks/personalized-block-controller.js
+++ b/packages/server/personalized-blocks/personalized-block-controller.js
@@ -22,13 +22,18 @@ module.exports = {
  * @apiSuccess {personalizedBlock[]} items list of personalized blocks
  */
 async function listPersonalizedBlocks(req, res, next) {
-  const { groupId, searchTerm } = req.query;
-  if (!groupId) {
-    return next(new createHttpError.BadRequest(ERROR_CODES.GROUP_ID_REQUIRED));
+  const { groupId, templateId, searchTerm } = req.query;
+  if (!groupId || !templateId) {
+    return next(
+      new createHttpError.BadRequest(
+        ERROR_CODES.GROUP_ID_AND_TEMPLATE_ID_REQUIRED
+      )
+    );
   }
 
   const personalizedBlocks = await personalizedBlockService.getPersonalizedBlocks(
     groupId,
+    templateId,
     searchTerm
   );
   return res.json({ items: personalizedBlocks });
@@ -41,6 +46,7 @@ async function listPersonalizedBlocks(req, res, next) {
  * @apiGroup PersonalizedBlocks
  *
  * @apiParam (Body) {String} groupId the group of the personalized block
+ * @apiParam (Body) {String} templateId the template of the personalized block
  * @apiParam (Body) {String} name name of the block
  * @apiParam (Body) {String} category category of the block
  * @apiParam (Body) {Mixed} content content of the block
@@ -49,10 +55,10 @@ async function listPersonalizedBlocks(req, res, next) {
  * @apiSuccess {personalizedBlock} personalizedBlock created
  */
 async function createPersonalizedBlock(req, res, next) {
-  const { groupId, name, category, content } = req.body;
+  const { groupId, templateId, name, category, content } = req.body;
   const { user } = req;
 
-  if (!groupId || !name || !content) {
+  if (!groupId || !templateId || !name || !content) {
     return next(
       new createHttpError.BadRequest(
         ERROR_CODES.MISSING_PARAMETERS_PERSONALIZED_BLOCK
@@ -63,6 +69,7 @@ async function createPersonalizedBlock(req, res, next) {
   const newPersonalizedBlock = await personalizedBlockService.addPersonalizedBlock(
     { name, category, content },
     groupId,
+    templateId,
     user.id
   );
 

--- a/packages/server/personalized-blocks/personalized-block-schema.js
+++ b/packages/server/personalized-blocks/personalized-block-schema.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const { Schema } = require('mongoose');
-const { GroupModel, UserModel } = require('../constant/model.names.js');
+const {
+  GroupModel,
+  UserModel,
+  TemplateModel,
+} = require('../constant/model.names.js');
 const { ObjectId, Mixed } = Schema.Types;
 
 /**
@@ -37,6 +41,11 @@ const PersonalizedBlockSchema = Schema(
       type: ObjectId,
       ref: UserModel,
       required: [true, 'User is required'],
+    },
+    _template: {
+      type: ObjectId,
+      ref: TemplateModel,
+      required: [true, 'Template is required'],
     },
     createdAt: {
       type: Date,

--- a/packages/server/personalized-blocks/personalized-block-service.js
+++ b/packages/server/personalized-blocks/personalized-block-service.js
@@ -13,13 +13,16 @@ module.exports = {
   deletePersonalizedBlock,
 };
 
-async function getPersonalizedBlocks(groupId, searchTerm = '') {
+async function getPersonalizedBlocks(groupId, templateId, searchTerm = '') {
   try {
     // Initialize MongoDB aggregation query
     const query = PersonalizedBlocks.aggregate([
-      // Step 1: Filter personalized blocks by group
+      // Step 1: Filter personalized blocks by group and by template
       {
-        $match: { _group: mongoose.Types.ObjectId(groupId) },
+        $match: {
+          _group: mongoose.Types.ObjectId(groupId),
+          _template: mongoose.Types.ObjectId(templateId),
+        },
       },
 
       // Step 2: Join the "Users" collection to get details of the user who created each block
@@ -61,11 +64,12 @@ async function getPersonalizedBlocks(groupId, searchTerm = '') {
   }
 }
 
-async function addPersonalizedBlock(block, groupId, userId) {
+async function addPersonalizedBlock(block, groupId, templateId, userId) {
   const newBlock = await PersonalizedBlocks.create({
     ...block,
     _group: mongoose.Types.ObjectId(groupId),
     _user: mongoose.Types.ObjectId(userId),
+    _template: mongoose.Types.ObjectId(templateId),
     createdAt: new Date(),
   });
 

--- a/public/lang/badsender-en.js
+++ b/public/lang/badsender-en.js
@@ -116,7 +116,7 @@ module.exports = {
   'personalized-blocks-fetch-error':
     'An error occurred while fetching custom blocks.',
   'personalized-blocks-loading': 'Loading custom blocks...',
-  'personalized-blocks-empty': 'No custom blocks available.',
+  'personalized-blocks-empty': 'No custom blocks available for this template.',
   'personalized-blocks-empty-search': 'No results found for your search.',
   'personalized-blocks-search-placeholder': 'Search...',
 

--- a/public/lang/badsender-fr.js
+++ b/public/lang/badsender-fr.js
@@ -117,7 +117,8 @@ module.exports = {
   'personalized-blocks-fetch-error':
     "Une erreur s'est produite lors de la récupération des blocs personnalisés.",
   'personalized-blocks-loading': 'Chargement des blocs personnalisés...',
-  'personalized-blocks-empty': 'Aucun bloc personnalisé disponible.',
+  'personalized-blocks-empty':
+    'Aucun bloc personnalisé disponible pour ce template.',
   'personalized-blocks-empty-search':
     'Aucun résultat trouvé pour votre recherche.',
   'personalized-blocks-search-placeholder': 'Rechercher...',


### PR DESCRIPTION
### Feature: Filter Personalized Blocks by Template Origin Using Mailing ID

#### Description:

The objective of this feature is to solve the issue related to adding personalized blocks from one template (Template A) into an email based on another template (Template B). The solution aims to filter the personalized blocks according to the current template being used in the email.

#### Implementation Details:

##### Backend:

1. **Utilize Existing API Endpoint for Fetching Mail Information**
   - Note: An existing API endpoint that takes `mailingId` as a parameter returns detailed mail information, including the `templateId`.

2. **Extend API to Include Template-based Filtering**
   - File: `personalized-block-service.js`
   - Task:
     - Add a query parameter `templateId` in the `getPersonalizedBlocks` method.
     - Implement logic to filter blocks based on the `templateId`.

3. **Add `templateId` to Personalized Block Schema**
   - File: `personalized-block-schema.js`
   - Task:
     - Add `templateId` to the schema definition for personalized blocks.

##### Frontend:

1. **Create `badsender-current-mailing` Extension**
   - The extension will fetch detailed mail information using the current `mailingId` and update the ViewModel.
   - The ViewModel will include a new property, `currentMailing`, which will be an observable object containing all the mail information.

2. **Integrate Filtering Logic in Personalized Blocks List Component**
   - Modify the `fetchPersonalizedBlocks` method to include the `templateId` from `currentMailing` as a parameter during the API call to `getPersonalizedBlocks`.

3. **Update Create Logic in Save Block Modal Component**
   - File: `packages/editor/src/js/vue/components/save-block-modal/save-modal.js`
   - Task:
     - When creating a personalized block, pass the `templateId` from `currentMailing` to the relevant API endpoint. (Note: Updating a personalized block will not require sending the `templateId` again.)

4. **Handle Empty States**
   - Display a message "No personalized blocks available for this template" if no blocks are available for the current template.

#### Acceptance Criteria:

- All the detailed mail information, including `templateId`, is successfully fetched and stored in the ViewModel under the `currentMailing` property.
- The filter functions as expected, displaying only the blocks corresponding to the current template.
- The `templateId` is successfully passed when creating personalized blocks.
- An appropriate message is displayed when no blocks are available for the current template.

#### Time Estimate:

1 days

https://github.com/Badsender-com/LePatron.email/assets/80390318/4f8c1ae4-5087-4d93-9ca8-3f467357e286

