### PR TITLE
Preserving URL Formatting During CDN Exports

### DIFF
--- a/packages/server/group/group.schema.js
+++ b/packages/server/group/group.schema.js
@@ -3,7 +3,7 @@
 const { Schema } = require('mongoose');
 const mongooseHidden = require('mongoose-hidden')();
 
-const { normalizeString, trimString } = require('../utils/model');
+const { trimString } = require('../utils/model');
 const { encrypt, decrypt } = require('../utils/crpyto');
 const Status = require('./status');
 /**
@@ -55,7 +55,6 @@ const GroupSchema = Schema(
     },
     cdnEndPoint: {
       type: String,
-      set: normalizeString,
     },
     cdnButtonLabel: {
       type: String,


### PR DESCRIPTION

## Description: Preserving URL Formatting During CDN Exports

The problem originates from the backend schema. When I save group updates, it leads to changes due to the following code in the schema:

```js
    cdnEndPoint: {
      type: String,
      set: normalizeString,
    },
```

Simply remove `set: normalizeString,` from the second line, and everything works well.

### Warning from Existing Problem
When I update the CDN link with the special character `"`, it poses a problem. In the exported code, it is interpreted as if I closed the `"` of the image URL. As a result, an error occurs.

