### PR TITLE
Feat: DSC API Request with User-Agent

### DIFF
--- a/packages/server/esp/dsc/dscProvider.js
+++ b/packages/server/esp/dsc/dscProvider.js
@@ -14,7 +14,11 @@ class DscProvider {
 
   async connectApiCall() {
     return axios.get(`${config.dscUrl}`, {
-      headers: { apiKey: this.apiKey, 'Content-Type': 'application/json' },
+      headers: {
+        apiKey: this.apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': config.dscUserAgent,
+      },
     });
   }
 
@@ -49,6 +53,7 @@ class DscProvider {
       headers: {
         apiKey: this.apiKey,
         'Content-Type': 'application/json',
+        'User-Agent': config.dscUserAgent,
       },
     });
   }
@@ -57,7 +62,11 @@ class DscProvider {
     const url = `${config.dscUrl}/withTypeCampagne`;
     try {
       return await axios.post(url, restData, {
-        headers: { apiKey: this.apiKey, 'Content-Type': 'application/json' },
+        headers: {
+          apiKey: this.apiKey,
+          'Content-Type': 'application/json',
+          'User-Agent': config.dscUserAgent,
+        },
         params: { typeCampagne },
       });
     } catch (error) {
@@ -69,7 +78,11 @@ class DscProvider {
     const url = `${config.dscUrl}/withTypeCampagne/${campaignMailId}`;
     try {
       return await axios.put(url, restData, {
-        headers: { apiKey: this.apiKey, 'Content-Type': 'application/json' },
+        headers: {
+          apiKey: this.apiKey,
+          'Content-Type': 'application/json',
+          'User-Agent': config.dscUserAgent,
+        },
         params: { typeCampagne },
       });
     } catch (error) {

--- a/packages/server/node.config.js
+++ b/packages/server/node.config.js
@@ -61,6 +61,7 @@ const config = rc('lepatron', {
   },
   proxyUrl: process.env.QUOTAGUARDSTATIC_URL,
   dscUrl: process.env.DSC_ESP_URL,
+  dscUserAgent: process.env.DSC_USER_AGENT,
   NODE_ENV: process.env.NODE_ENV,
 });
 


### PR DESCRIPTION
## Description of changes 
### Before 
To call DSC API you had to be registered in their whitelisted Pp addresses list
When trying to call the DSC API from a non-whitelisted ip addresses, you would get:

Picture 1
![error_not_whitelisted](https://github.com/Badsender-com/LePatron.email/assets/135032615/397c5907-c6bd-4a11-96ff-96c7d08b0d68)

### After
To remove the need for DSC to whitelist every IP addresses, we will use a User-Agent provided in the request header to identify and get the authorization.
When trying to call the DSC API from a non-whitelisted ip addresses, you wil get:

Picture2
![image](https://github.com/Badsender-com/LePatron.email/assets/135032615/15ede0f3-edbf-45e3-8d66-547569b4a66e)

### How ? 
- Create an environment variable for the User-Agent
-  Add its value to the config
- Pass it as a header for every call to DSC in `DscProvider`.


## Notes
**Maybe we could extract the headers in an object since they are the same for all the request, to avoid duplication ?**

## Tests
On local env : 
- [x] Test on a non-whitelisted address IP, without the User-Agent header (see picture 1)
- [x] Test on a non-whitelisted with the User-Agent header (see picture 2)
- [x] Test on a non-whitelister with the User-Agent header and a bad naming :  

![error_bad_name](https://github.com/Badsender-com/LePatron.email/assets/135032615/ec3184c1-d11b-4f98-875f-1ebdeae163ac)
(The retrieved error message is the correct one)
