### PR TITLE
Fix: Improve DSC error handling

### DIFF
--- a/packages/editor/src/js/vue/components/esp/esp-send-mail.js
+++ b/packages/editor/src/js/vue/components/esp/esp-send-mail.js
@@ -114,6 +114,18 @@ const EspComponent = Vue.component('EspForm', {
         .catch((error) => {
           // handle error
           console.log(error);
+
+          /*
+            If the campaign for this profile should exist but was not found on DSC,
+            Then it was probably deleted on DSC's side.
+            So we allow the user to create a new one
+          */
+          if(error.response.status === 404) {
+            this.type = SEND_MODE.CREATION;
+            this.fetchProfileData(message);
+            return;
+          }
+
           this.vm.notifier.error(this.vm.t('error-server'));
         })
         .finally(() => {

--- a/packages/server/esp/dsc/dscProvider.js
+++ b/packages/server/esp/dsc/dscProvider.js
@@ -4,7 +4,12 @@ const mailingService = require('../../mailing/mailing.service.js');
 const ERROR_CODES = require('../../constant/error-codes.js');
 const config = require('../../node.config.js');
 const axios = require('../../config/axios');
-const { InternalServerError, Conflict, BadRequest } = require('http-errors');
+const {
+  InternalServerError,
+  Conflict,
+  BadRequest,
+  NotFound,
+} = require('http-errors');
 
 class DscProvider {
   constructor({ apiKey, ...data }) {
@@ -127,6 +132,10 @@ class DscProvider {
       };
     } catch (e) {
       logger.error({ error: e });
+
+      if (e?.status === 404) {
+        throw new NotFound('Campaign not found on DSC');
+      }
 
       throw e;
     }

--- a/packages/server/esp/dsc/dscProvider.js
+++ b/packages/server/esp/dsc/dscProvider.js
@@ -85,6 +85,10 @@ class DscProvider {
       throw new BadRequest(message);
     }
 
+    if (status === 409) {
+      throw new Conflict(message);
+    }
+
     // Log the error and throw a generic error if it doesn't match specific cases
     logger.error('Error in API call:', error);
     throw new Error('An error occurred while communicating with the API.');

--- a/packages/server/profile/profile.service.js
+++ b/packages/server/profile/profile.service.js
@@ -202,7 +202,13 @@ async function sendEspCampaign({
   const { subject, campaignMailName, planification } = espSendingMailData;
   const profile = await findOne(profileId);
 
-  await checkIfMailAlreadySentToProfile({ profileId, mailingId });
+  /*
+    For DSC, creating a new campaign from the same profile is allowed 
+    if the campaign was deleted on DSC's side
+  */
+  if (type !== 'DSC') {
+    await checkIfMailAlreadySentToProfile({ profileId, mailingId });
+  }
 
   const {
     apiKey,


### PR DESCRIPTION
## Description of changes
1. Send a feedback to the client when trying to create a campaign on DSC with a name that is already take 
=> Throw the error caught when doing the POST creation request 

2. When updating a campaign for a dsc profile, if the campaign was deleted on dsc, the user would not be able to  make any change to this campaign. 
Instead, switch to creation mode and allow the user to create a new campaign for this mail and dsc profile.
=> On the Front end, instead of displaying the not found error, catch it and switch to update mode