### PR TITLE
Release Staging : operation update on save delivery

### DIFF
--- a/packages/server/esp/adobe/adobeProvider.js
+++ b/packages/server/esp/adobe/adobeProvider.js
@@ -383,6 +383,7 @@ class AdobeProvider {
     return replacedHtml;
   }
 
+  // TODO verify if the isModel is a problem for delivery save
   async saveDeliveryTemplate({ internalName, folderFullName, contentHtml }) {
     return this.makeSoapRequest({
       soapAction: 'xtk:persist#Write',
@@ -390,7 +391,7 @@ class AdobeProvider {
       <m:Write xmlns:m="urn:xtk:persist|xtk:session">
         <sessiontoken></sessiontoken>
         <domDoc xsi:type='ns:Element'>
-          <delivery xtkschema="nms:delivery" isModel="1" deliveryMode="4" internalName="${internalName}">
+          <delivery xtkschema="nms:delivery" isModel="1" deliveryMode="4" internalName="${internalName}" _operation="update">
             <content>
               <html>
                 <source>

--- a/packages/server/esp/adobe/adobeProvider.js
+++ b/packages/server/esp/adobe/adobeProvider.js
@@ -315,7 +315,6 @@ class AdobeProvider {
     });
 
     await this.saveDeliveryTemplate({
-      deliveryLabel: name,
       internalName: adobe.deliveryInternalName,
       folderFullName: adobe.folderFullName,
       contentHtml: htmlWithAdobeUrls,
@@ -384,19 +383,14 @@ class AdobeProvider {
     return replacedHtml;
   }
 
-  async saveDeliveryTemplate({
-    deliveryLabel,
-    internalName,
-    folderFullName,
-    contentHtml,
-  }) {
+  async saveDeliveryTemplate({ internalName, folderFullName, contentHtml }) {
     return this.makeSoapRequest({
       soapAction: 'xtk:persist#Write',
       xmlBodyRequest: `
       <m:Write xmlns:m="urn:xtk:persist|xtk:session">
         <sessiontoken></sessiontoken>
         <domDoc xsi:type='ns:Element'>
-          <delivery xtkschema="nms:delivery" isModel="1" deliveryMode="4" internalName="${internalName}" label="${deliveryLabel}">
+          <delivery xtkschema="nms:delivery" isModel="1" deliveryMode="4" internalName="${internalName}">
             <content>
               <html>
                 <source>


### PR DESCRIPTION
"Côté adobe lorsqu'ils créent un "proof" (delivery de test) à partir du template exporté, cela demande une adresse email sur laquelle envoyer.
Elle est saisie.
Si on met à jour le template avec un nouvel export, alors l'adresse du proof disparait."

Les infos étaient écrasées sans le _operation="update" qui est un attribut de xtkPersist