### PR TITLE
perf(translation): offload heavy work after 202 response

### DIFF
--- a/packages/server/translation/mosaico-text-injector.js
+++ b/packages/server/translation/mosaico-text-injector.js
@@ -87,9 +87,11 @@ function injectTexts(mailing, translations) {
 function validateTranslations(originalTexts, translations) {
   const originalKeys = Object.keys(originalTexts);
   const translatedKeys = Object.keys(translations);
+  const originalSet = new Set(originalKeys);
+  const translatedSet = new Set(translatedKeys);
 
-  const missing = originalKeys.filter((k) => !translatedKeys.includes(k));
-  const extra = translatedKeys.filter((k) => !originalKeys.includes(k));
+  const missing = originalKeys.filter((k) => !translatedSet.has(k));
+  const extra = translatedKeys.filter((k) => !originalSet.has(k));
 
   return {
     isValid: missing.length === 0 && extra.length === 0,

--- a/packages/server/translation/translation-batch.utils.js
+++ b/packages/server/translation/translation-batch.utils.js
@@ -54,10 +54,12 @@ function splitIntoBatches(texts, batchLimits) {
 }
 
 /**
- * Translate texts in batches to avoid API timeouts
+ * Translate already-split batches sequentially.
+ * Splitting is done by the caller so that batch counts can be reported
+ * before any provider call (avoids the previous duplicate split + extract).
  * @param {Object} params
  * @param {Object} params.provider - AI provider instance
- * @param {Object} params.texts - Texts to translate
+ * @param {Array<Object>} params.batches - Pre-split batches
  * @param {string} params.sourceLanguage - Source language
  * @param {string} params.targetLanguage - Target language
  * @param {string} [params.context] - Additional context for translation (used by DeepL)
@@ -66,21 +68,19 @@ function splitIntoBatches(texts, batchLimits) {
  */
 async function translateInBatches({
   provider,
-  texts,
+  batches,
   sourceLanguage,
   targetLanguage,
   context,
   onBatchProgress,
 }) {
-  const batchLimits = provider.getBatchLimits
-    ? provider.getBatchLimits()
-    : DEFAULT_BATCH_LIMITS;
-  const batches = splitIntoBatches(texts, batchLimits);
+  const totalKeys = batches.reduce(
+    (sum, batch) => sum + Object.keys(batch).length,
+    0
+  );
 
   logger.log(
-    `[Translation] Translating ${Object.keys(texts).length} keys in ${
-      batches.length
-    } batch(es)`
+    `[Translation] Translating ${totalKeys} keys in ${batches.length} batch(es)`
   );
 
   // Translate batches sequentially to avoid rate limiting

--- a/packages/server/translation/translation-job.schema.js
+++ b/packages/server/translation/translation-job.schema.js
@@ -5,9 +5,9 @@ const { Schema } = require('mongoose');
 const ProgressSchema = new Schema(
   {
     currentBatch: { type: Number, default: 0 },
-    totalBatches: { type: Number, required: true },
+    totalBatches: { type: Number, default: 0 },
     keysTranslated: { type: Number, default: 0 },
-    totalKeys: { type: Number, required: true },
+    totalKeys: { type: Number, default: 0 },
   },
   { _id: false }
 );

--- a/packages/server/translation/translation-jobs.js
+++ b/packages/server/translation/translation-jobs.js
@@ -23,24 +23,39 @@ const JobStatus = {
 /**
  * Create a new translation job
  * @param {Object} params - Job parameters
- * @param {number} params.totalKeys - Total number of keys to translate
- * @param {number} params.totalBatches - Total number of batches
  * @param {string} params.userId - Owner user ID for authorization
  * @returns {Promise<Object>} The created job
  */
-async function createJob({ totalKeys, totalBatches, userId }) {
+async function createJob({ userId }) {
   const doc = await TranslationJobs.create({
     jobId: uuidv4(),
     userId,
     status: JobStatus.PENDING,
     progress: {
       currentBatch: 0,
-      totalBatches,
+      totalBatches: 0,
       keysTranslated: 0,
-      totalKeys,
+      totalKeys: 0,
     },
   });
   return doc.toObject();
+}
+
+/**
+ * Set the totals on a job once they are known (after extraction + batching)
+ * @param {string} jobId - Job ID
+ * @param {{ totalKeys: number, totalBatches: number }} totals
+ */
+async function setTotals(jobId, { totalKeys, totalBatches }) {
+  await TranslationJobs.updateOne(
+    { jobId },
+    {
+      $set: {
+        'progress.totalKeys': totalKeys,
+        'progress.totalBatches': totalBatches,
+      },
+    }
+  );
 }
 
 /**
@@ -138,6 +153,7 @@ async function isCancelled(jobId) {
 module.exports = {
   JobStatus,
   createJob,
+  setTotals,
   getJob,
   updateBatchProgress,
   setCompleted,

--- a/packages/server/translation/translation.controller.js
+++ b/packages/server/translation/translation.controller.js
@@ -47,44 +47,10 @@ async function duplicateAndTranslate(req, res) {
     throw createError(400, ERROR_CODES.TRANSLATION_TARGET_LANGUAGE_REQUIRED);
   }
 
-  // Get original mailing
-  const originalMailing = await mailingService.findOne(mailingId);
-
-  // Get user's group
-  const groupId =
-    (user.group && user.group.id) ||
-    (originalMailing._company && originalMailing._company.toString());
-
-  // Get template markup for translation protection config
-  let templateMarkup = null;
-  if (originalMailing._wireframe) {
-    const template = await Templates.findById(originalMailing._wireframe, {
-      markup: 1,
-    });
-    templateMarkup = template?.markup || null;
-  }
-
-  // Detect source language if not provided
-  const detectedSourceLanguage =
-    sourceLanguage === 'auto'
-      ? translationService.detectSourceLanguage(originalMailing)
-      : sourceLanguage;
-
-  // Get batch info for progress tracking
-  const batchInfo = await translationService.getBatchInfo({
-    groupId,
-    mailing: {
-      name: originalMailing.name,
-      data: originalMailing.data,
-      previewHtml: originalMailing.previewHtml,
-    },
-    templateMarkup,
-  });
-
-  // Create a job for progress tracking (include userId for authorization)
+  // Create the job up-front so the client can start polling immediately.
+  // Heavy work (DB lookups, text extraction, batching) is moved to the
+  // background task below to keep this handler from blocking the event loop.
   const job = await translationJobs.createJob({
-    totalKeys: batchInfo.totalKeys,
-    totalBatches: batchInfo.totalBatches,
     userId: user.id || user._id.toString(),
   });
 
@@ -94,14 +60,11 @@ async function duplicateAndTranslate(req, res) {
   // Process translation asynchronously (fire-and-forget after the 202 response)
   processTranslationAsync({
     jobId: job.jobId,
-    originalMailing,
     mailingId,
     user,
-    groupId,
-    sourceLanguage: detectedSourceLanguage,
+    sourceLanguage,
     targetLanguage,
     newName,
-    templateMarkup,
     workspaceId,
     folderId,
   }).catch((error) => {
@@ -116,14 +79,11 @@ async function duplicateAndTranslate(req, res) {
  */
 async function processTranslationAsync({
   jobId,
-  originalMailing,
   mailingId,
   user,
-  groupId,
   sourceLanguage,
   targetLanguage,
   newName,
-  templateMarkup,
   workspaceId,
   folderId,
 }) {
@@ -147,6 +107,28 @@ async function processTranslationAsync({
       return;
     }
 
+    // Heavy work that used to run synchronously inside the HTTP handler is
+    // now done here so the 202 response can be sent without blocking the
+    // event loop.
+    const originalMailing = await mailingService.findOne(mailingId);
+
+    const groupId =
+      (user.group && user.group.id) ||
+      (originalMailing._company && originalMailing._company.toString());
+
+    let templateMarkup = null;
+    if (originalMailing._wireframe) {
+      const template = await Templates.findById(originalMailing._wireframe, {
+        markup: 1,
+      });
+      templateMarkup = template?.markup || null;
+    }
+
+    const detectedSourceLanguage =
+      sourceLanguage === 'auto'
+        ? translationService.detectSourceLanguage(originalMailing)
+        : sourceLanguage;
+
     // Translate the mailing
     const {
       mailing: translatedData,
@@ -160,9 +142,11 @@ async function processTranslationAsync({
         data: originalMailing.data,
         previewHtml: originalMailing.previewHtml,
       },
-      sourceLanguage,
+      sourceLanguage: detectedSourceLanguage,
       targetLanguage,
       templateMarkup,
+      onTotalsKnown: ({ totalKeys, totalBatches }) =>
+        translationJobs.setTotals(jobId, { totalKeys, totalBatches }),
       onBatchProgress,
     });
 
@@ -212,7 +196,7 @@ async function processTranslationAsync({
       mailingName: duplicatedMailing.name,
       previewGenerated,
       stats,
-      sourceLanguage,
+      sourceLanguage: detectedSourceLanguage,
       targetLanguage,
       warningKeys: [
         'translation.warnings.checkLinks',

--- a/packages/server/translation/translation.service.js
+++ b/packages/server/translation/translation.service.js
@@ -27,38 +27,8 @@ module.exports = {
   translateText,
   getAvailableLanguages,
   detectSourceLanguage,
-  getBatchInfo,
   extractFullContext,
 };
-
-/**
- * Get batch info for a mailing (used for progress tracking)
- * @param {Object} params
- * @param {Object} params.mailing - Mailing document
- * @param {string} [params.templateMarkup] - Template HTML markup for protection config
- * @returns {Promise<Object>} Batch info { totalKeys, totalBatches }
- */
-// eslint-disable-next-line no-unused-vars
-async function getBatchInfo({ mailing, templateMarkup }) {
-  // Parse protection config from template markup (if provided)
-  const protectionConfig = templateMarkup
-    ? parseProtectionConfig(templateMarkup)
-    : null;
-
-  // Extract texts from mailing (respecting protection config)
-  const textsToTranslate = extractTexts(mailing, protectionConfig);
-  const totalKeys = Object.keys(textsToTranslate).length;
-
-  if (totalKeys === 0) {
-    return { totalKeys: 0, totalBatches: 0 };
-  }
-
-  const batches = splitIntoBatches(textsToTranslate);
-  return {
-    totalKeys,
-    totalBatches: batches.length,
-  };
-}
 
 /**
  * Translate an entire mailing
@@ -68,6 +38,7 @@ async function getBatchInfo({ mailing, templateMarkup }) {
  * @param {string} params.sourceLanguage - Source language code (or 'auto')
  * @param {string} params.targetLanguage - Target language code
  * @param {string} [params.templateMarkup] - Template HTML markup for protection config
+ * @param {Function} [params.onTotalsKnown] - Callback invoked once with ({ totalKeys, totalBatches }) before any provider call
  * @param {Function} [params.onBatchProgress] - Callback for batch progress (batchNumber, keysInBatch)
  * @returns {Promise<Object>} Translated mailing data
  */
@@ -77,6 +48,7 @@ async function translateMailing({
   sourceLanguage,
   targetLanguage,
   templateMarkup,
+  onTotalsKnown,
   onBatchProgress,
 }) {
   // Get active translation feature with integration
@@ -111,6 +83,9 @@ async function translateMailing({
 
   if (stats.fieldCount === 0) {
     // Nothing to translate
+    if (onTotalsKnown) {
+      await onTotalsKnown({ totalKeys: 0, totalBatches: 0 });
+    }
     return {
       mailing,
       stats: {
@@ -129,6 +104,20 @@ async function translateMailing({
     providerFeatureConfig
   );
 
+  // Split into batches up-front so the caller can be notified of the totals
+  // before any provider call happens (used for live progress reporting).
+  const batchLimits = provider.getBatchLimits
+    ? provider.getBatchLimits()
+    : undefined;
+  const batches = splitIntoBatches(textsToTranslate, batchLimits);
+
+  if (onTotalsKnown) {
+    await onTotalsKnown({
+      totalKeys: stats.fieldCount,
+      totalBatches: batches.length,
+    });
+  }
+
   // Extract full context for DeepL (improves translation quality)
   // LLM providers will ignore this parameter
   const context = extractFullContext(textsToTranslate);
@@ -137,7 +126,7 @@ async function translateMailing({
   try {
     translations = await translateInBatches({
       provider,
-      texts: textsToTranslate,
+      batches,
       sourceLanguage,
       targetLanguage,
       context,


### PR DESCRIPTION
- move mailing/template lookup, text extraction and batching from the HTTP handler to the background task so POST /duplicate-translate returns in ~ms instead of ~8s and no longer blocks the event loop
- drop translationService.getBatchInfo: translateMailing now handles batching itself and reports totals via an onTotalsKnown callback, removing a duplicate parseProtectionConfig + extractTexts pass per job
- translateInBatches now accepts pre-split batches so the split is done once by the caller, before any provider call
- translationJobs.createJob no longer requires totals; new setTotals updates them once they are known. Progress schema defaults to 0.
- validateTranslations: use Sets instead of filter+includes (O(n²) → O(n))