### PR TITLE
fix(crm-intelligence): expose features array to the marketing landing…

### DIFF
--- a/packages/ui/routes/crm-intelligence/index.vue
+++ b/packages/ui/routes/crm-intelligence/index.vue
@@ -75,6 +75,9 @@ export default {
         ? 'https://www.badsender.com/contact/'
         : 'https://www.badsender.com/en/contact/';
     },
+    features() {
+      return this.$t('crmIntelligence.marketing.features');
+    },
     ...mapState(USER, {
       userInfo: 'info',
     }),


### PR DESCRIPTION
… page

The template passes :features="features" to BsMarketingLandingPage but no computed/data property of that name existed, so the prop was undefined and the features grid (six feature cards under "Drive your data-driven strategy") rendered as zero rows.

Add a features computed that returns the translated array, matching the pattern already used in email-builder-placeholder.vue.