### PR TITLE
fix(ui): retour éditeur ramène à /mailings avec le bon workspace

### DIFF
--- a/packages/server/mailing/mailing.schema.js
+++ b/packages/server/mailing/mailing.schema.js
@@ -458,9 +458,14 @@ MailingSchema.statics.findOneForMosaico = async function findOneForMosaico(
   if (user?.isAdmin) {
     redirectUrl = `/groups/${groupId}?redirectTab=mailings`;
   } else {
+    // Target the Email Builder route directly (`/mailings`), not the app root
+    // (`/`). The root only redirects to the first enabled module and was
+    // dropping the query string, landing the user on an empty page with no
+    // sidebar. `/mailings?fid=/wid=` mounts the workspace tree on the right
+    // folder/workspace.
     redirectUrl = mailing?._parentFolder
-      ? `/?fid=${mailing._parentFolder}`
-      : `/?wid=${mailing._workspace}`;
+      ? `/mailings?fid=${mailing._parentFolder}`
+      : `/mailings?wid=${mailing._workspace}`;
   }
 
   return {

--- a/packages/ui/routes/index.vue
+++ b/packages/ui/routes/index.vue
@@ -13,7 +13,7 @@ import { USER, IS_ADMIN } from '~/store/user';
 
 export default {
   ...MailingsPage,
-  middleware({ store, redirect }) {
+  middleware({ store, redirect, query }) {
     // Super admin goes to groups management
     if (store.getters[`${USER}/${IS_ADMIN}`]) {
       return redirect('/groups');
@@ -28,12 +28,15 @@ export default {
 
     // Redirect to first enabled module:
     // Priority: Email Builder > CRM Intelligence
+    // Preserve the query string (e.g. ?fid=/?wid= when landing on `/` from an
+    // old link or the editor back arrow) so the workspace tree opens on the
+    // right folder/workspace instead of an empty page.
     if (isEmailBuilderEnabled) {
-      return redirect('/mailings');
+      return redirect('/mailings', query);
     }
 
     if (isCrmIntelligenceEnabled) {
-      return redirect('/crm-intelligence');
+      return redirect('/crm-intelligence', query);
     }
 
     // If no modules are enabled, continue to show Email Builder placeholder


### PR DESCRIPTION
## Problème

La flèche retour de l'éditeur de mail renvoyait vers `/?fid=` / `/?wid=` (racine de l'app). La home `/` redirige vers le premier module activé **mais sans conserver le query string** → `fid`/`wid` perdu → page vide sans sidebar.

## Correctif

- **Serveur** (`mailing.schema.js`) : `redirectUrl` cible désormais directement `/mailings?fid=` / `/mailings?wid=`, la vraie route du module qui monte l'arbre des workspaces.
- **Front** (`routes/index.vue`) : le middleware de `/` préserve le query string au redirect (filet pour d'anciens liens `/?fid=`).

## À tester
- [ ] Ouvrir un mail (dans un workspace ou un dossier) → **flèche retour** de l'éditeur → revient sur `/mailings` avec le bon workspace/dossier sélectionné et la sidebar affichée.

> Note : la persistance de l'**expansion** de l'arbre au refresh (sous-dossiers qui se replient) est un autre sujet, non traité ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)