### PR TITLE
fix(editor): drag & drop d'image depuis le Finder vers un bloc email

### DIFF
--- a/packages/editor/src/css/badsender-editor.less
+++ b/packages/editor/src/css/badsender-editor.less
@@ -1040,6 +1040,19 @@ body {
   pointer-events: auto;
 }
 
+// During an OS file drag, the mouse :hover state is not reliably triggered,
+// so .mo-uploadzone (the jQuery File Upload dropZone) would stay
+// pointer-events:none and never receive the drop. fudroppable adds
+// .ui-state-highlight (a drag is active anywhere in the window) and
+// .ui-state-draghover (the drag is over this image) — re-enable the dropzone
+// in those states so drag-and-drop from the Finder/file explorer works again.
+#main-edit-area .img-wysiwyg.ui-state-highlight .workzone,
+#main-edit-area .img-wysiwyg.ui-state-highlight .mo-uploadzone,
+#main-edit-area .img-wysiwyg.ui-state-draghover .workzone,
+#main-edit-area .img-wysiwyg.ui-state-draghover .mo-uploadzone {
+  pointer-events: auto;
+}
+
 // Individual tool button - ghost style
 #main-edit-area .tools .tool {
   display: flex;

--- a/packages/editor/src/tmpl/img-wysiwyg.tmpl.html
+++ b/packages/editor/src/tmpl/img-wysiwyg.tmpl.html
@@ -37,7 +37,7 @@
   <div title="Drop an image here or click the upload button" data-bind="attr: { title: $root.t('Drop an image here or click the upload button') }, tooltips: {}" class="workzone" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; overflow: hidden;">
     <!-- ko if: _src.preloaded && _src() != _src.preloaded() -->PRELOADING....<!-- /ko -->
     <!-- ko if: _src() != '' -->
-      <input class="fileupload withfile" type="file" name="files[]" data-bind="fileupload: { data: _src, onerror: $root.notifier.error, onfile: $root.mailingGallery.unshift.bind($root.mailingGallery), canvasPreview: true, cropImage: true }" style="z-index: -20; position: absolute; top: 0; left: 0; right: 0; bottom: 0; min-width: 100%; min-height: 100%; font-zie: 999px; text-align: right; filter: alpha(opacity=0); opacity: 0; outline: none; cursor: inherit; display: block">
+      <input class="fileupload withfile" type="file" name="files[]" data-bind="fileupload: { data: _src, onerror: $root.notifier.error, onfile: $root.loadMailingImage, canvasPreview: true }" style="z-index: -20; position: absolute; top: 0; left: 0; right: 0; bottom: 0; min-width: 100%; min-height: 100%; font-zie: 999px; text-align: right; filter: alpha(opacity=0); opacity: 0; outline: none; cursor: inherit; display: block">
     <!-- /ko -->
     <div class="progress" style="opacity: .5; width: 80%; margin-left: 10%; position: absolute; bottom: 30%; height: 20px; border: 2px solid black;">
       <div class="progress-bar progress-bar-success" style="height: 20px; background-color: black; "></div>


### PR DESCRIPTION
## Problème

Le drag & drop d'une image depuis le Finder (ou explorateur de fichiers OS) directement vers la zone d'un bloc image dans l'éditeur d'email ne fonctionnait pas correctement. Deux régressions distinctes :

1. **Le drop ne déclenchait rien.** Rien ne se passait au dépôt du fichier.
2. **Sur un bloc avec image existante**, le drop ouvrait l'éditeur de crop et ajoutait l'image à la galerie, **sans remplacer** l'image du bloc.

À noter : le drop Finder → galerie fonctionnait, et le drag galerie → bloc email aussi. Seul le drop Finder → bloc était cassé.

## Cause racine

**Régression 1 — `pointer-events`.** Le commit de redesign de la toolbar (`98185934`) a ajouté `pointer-events: none` sur `.mo-uploadzone` (réactivé uniquement au `:hover` souris) pour laisser le hover atteindre la toolbar du bloc. Or `.mo-uploadzone` est la `dropZone` enregistrée auprès de jQuery File Upload (`fileupload.js:134`), et le `:hover` souris ne se déclenche pas de façon fiable pendant un drag de fichier OS → la zone restait inerte et ne recevait jamais le drop. Le commentaire Mosaico d'origine documentait justement ce besoin (`style_mosaico.less:395`).

**Régression 2 — input "withfile".** Dans `img-wysiwyg.tmpl.html`, l'input fileupload du cas "image présente" était configuré différemment de celui du cas "bloc vide" : `cropImage: true` (ouvrait l'éditeur) + `onfile: mailingGallery.unshift` (ajout brut). Le flux crop interrompait la mise à jour de `_src`, d'où l'image non remplacée.

## Correction

- **CSS** (`badsender-editor.less`) : réactivation de `pointer-events: auto` sur `.workzone` / `.mo-uploadzone` quand le bloc porte `.ui-state-highlight` / `.ui-state-draghover` (classes posées par `fudroppable` durant un drag). Le hover-pour-la-toolbar reste inchangé ; on ne réactive la dropzone que pendant un drag.
- **Template** (`img-wysiwyg.tmpl.html`) : alignement de l'input "withfile" sur l'input "bloc vide" — suppression de `cropImage`, `onfile` passé à `loadMailingImage` (ajout galerie avec déduplication). Le drop remplace désormais directement l'image du bloc.

## Comportement après fix

Que le bloc soit vide ou déjà rempli, un drop depuis le Finder :
- remplace directement l'image du bloc (sans éditeur de crop)
- ajoute l'image à la galerie du mailing (sans doublon)

Le crop reste actif là où il a du sens (upload via la galerie).

## Tests manuels à effectuer

- [ ] Drop Finder sur un bloc **vide** → image insérée + ajoutée à la galerie
- [ ] Drop Finder sur un bloc **avec image** → image remplacée + ajoutée à la galerie
- [ ] Hover sur un bloc image → toolbar accessible (pas de régression)
- [ ] Drag galerie → bloc → fonctionne toujours
- [ ] Drop Finder → galerie → fonctionne toujours (avec crop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)