### PR TITLE
docs: setup gallery redesign V1 project structure and references

### DIFF
--- a/CLAUDE.gallery.md
+++ b/CLAUDE.gallery.md
@@ -1,0 +1,327 @@
+# CLAUDE.md — Refonte galerie d'images LePatron (MVP V1)
+
+> Ce fichier est lu automatiquement par Claude Code à chaque session sur ce dépôt.
+> Il contient tout le contexte nécessaire pour travailler sur la **refonte de la galerie d'images** de LePatron.
+> Il ne remplace PAS les conventions générales du projet : il s'y ajoute, scopé à ce chantier.
+
+---
+
+## 1. Contexte produit
+
+**Projet** : refonte de la galerie d'images de LePatron, l'outil WYSIWYG de création d'emails de Badsender.
+
+**Approche** : itération par phases. Cette V1 améliore l'existant **sans introduire de nouveaux concepts produit**. Les fonctionnalités plus ambitieuses (collections, panneau droit, bulk, soft delete) sont reportées explicitement en V2+.
+
+**Problème actuel** :
+
+- Vignettes trop grosses, mal calibrées, libellés invisibles
+- Pas de recherche sur les images
+- Impossible de relancer l'éditeur sur une image déjà uploadée
+- Galerie "Commun au template" presque inutilisée
+
+**Cibles utilisateurs** :
+
+- **Marie, marketeer (principal)** : multitâche, sous deadline, veut retrouver vite la bonne image
+- **Alex, freelance/agence (secondaire)** : plus exigeant, utilise les fonctionnalités avancées
+
+**Objectif V1** : améliorer significativement la galerie sur les 3 plus gros irritants (vignettes/lisibilité, recherche, édition rétroactive) **sans rien casser ni rien complexifier**.
+
+---
+
+## 2. ⚠️ Principe directeur : ISO comportement existant
+
+**Cette V1 améliore l'UI/UX, la recherche, et ajoute l'édition rétroactive et le renommage. Rien d'autre dans le comportement utilisateur ne doit changer.**
+
+Conséquences concrètes à respecter :
+
+- L'upload dans la galerie continue de déclencher l'éditeur Konva
+- L'upload direct dans l'email continue de déclencher le resize auto
+- La suppression d'une image dans la galerie ne propage rien dans les emails (comportement actuel)
+- Pas de notion de "corbeille" : la suppression reste définitive et immédiate (comme aujourd'hui)
+- Pas d'avertissement à la suppression (l'image dans les emails n'est pas affectée, donc rien à avertir)
+- L'API consommée par Mosaico reste compatible à 100%
+
+**Tout ce qui n'est pas explicitement listé dans le périmètre V1 (section 3) doit conserver le comportement actuel.**
+
+---
+
+## 3. Périmètre MVP V1
+
+### Inclus dans la V1
+
+1. **Refonte UI/UX du panneau galerie (panneau gauche existant)**
+
+   - Vignettes plus petites et standardisées (thumbnails carrés générés via Sharp)
+   - Libellé visible sous chaque vignette
+   - Overlay au survol avec actions rapides (éditer, supprimer)
+   - Damier sur fond transparent (PNG/GIF), fond plein pour les JPG
+   - Zone d'upload réduite et discrète quand des images existent
+   - Compteur d'images affiché
+   - Scroll virtualisé pour gérer les grandes galeries
+
+2. **Recherche et filtres**
+
+   - Barre de recherche sur le libellé
+   - Filtres rapides par type de fichier : **JPG, PNG, GIF** (toutes variantes de casse normalisées en lowercase à l'upload)
+   - Filtres rapides par date d'upload (récent / ancien)
+
+3. **Tooltip au survol d'une vignette**
+
+   - Libellé complet (utile si tronqué dans l'affichage)
+   - Dimensions originales
+   - Format
+   - Date d'upload
+
+4. **Actions sur une image**
+
+   - **Éditer** : relance l'éditeur Konva sur l'image existante (NOUVEAU)
+   - **Renommer le libellé** : le nom de fichier technique reste inchangé (NOUVEAU)
+   - **Supprimer** : ISO comportement actuel, pas d'avertissement, pas de corbeille
+   - **Télécharger** : ISO comportement actuel
+
+5. **Préparation technique pour évolutions futures**
+
+   - Champ `source` sur chaque image (default `upload`, futur `dam_bynder`, etc.)
+   - Champ `externalMetadata` (objet JSON libre)
+   - Aucun impact UI, juste deux champs en plus dans le modèle
+
+6. **Migration des données existantes**
+   - Script de migration pour générer les thumbnails standardisés
+   - Initialisation du champ `label` (libellé) à partir du nom de fichier
+
+### Hors scope V1 (reporté V2+)
+
+- **Architecture 3 colonnes** (panneau droit dédié)
+- **Collections** (création, gestion, navigation, vue "Non classées")
+- **Sélection multiple et bulk actions** (supprimer / collections en masse)
+- **Soft delete et corbeille 30 jours** + UI de restauration
+- **Mode Détails** complet (panneau enrichi avec métadonnées étendues, usage, etc.)
+- **Indicateur d'usage** ("utilisée dans X email(s)") affiché ou utilisé
+- **Avertissement à la suppression**
+- **Question du lien image ↔ email** (cascade ou pas en cas de modification/suppression — décision produit reportée explicitement)
+
+### Hors scope V3+ (encore plus tard)
+
+- Tagging automatique IA à l'upload (recherche thématique)
+- Intégration DAM clients via API (Bynder, Cloudinary, Frontify…)
+- Vues intelligentes prédéfinies (Récents, Jamais utilisées, Mes uploads)
+- Système de rôles
+- Transfert d'images entre galeries
+- Historique des versions
+
+---
+
+## 4. Décisions produit reportées en V2+ (à NE PAS rouvrir dans la V1)
+
+Ces points ont été débattus longuement en phase de cadrage. Ils sont volontairement reportés. **Ne pas les ré-implémenter, même partiellement, dans la V1.**
+
+### Lien image ↔ email
+
+Le comportement actuel est **strictement préservé** dans la V1.
+
+- Supprimer une image de la galerie ne l'affecte pas dans les emails qui l'utilisent (les emails embarquent leur propre copie)
+- Modifier une image dans la galerie ne propage rien
+- Aucune cascade, aucun lien fort
+
+La question d'introduire un lien plus fort (pour permettre "modifier le logo partout en une fois", par exemple) est reportée en V2+ et nécessitera une discussion produit dédiée.
+
+### Collections vs dossiers vs tags
+
+Après débat, le modèle retenu pour la V2 est : **collections** (regroupements non-exclusifs, créés par les utilisateurs, partagés entre tous les utilisateurs du template). Pas de dossiers, pas de tags utilisateur.
+
+### Workspaces et galerie
+
+Pas de lien entre les workspaces et la galerie. La galerie reste rattachée au template (galerie commune) ou à l'email (galerie spécifique). Décision reportée en V2+.
+
+---
+
+## 5. Architecture technique cible (V1)
+
+### Disposition
+
+L'éditeur LePatron a un **panneau latéral gauche** d'environ 400px (largeur fixe, 364px utiles avec padding). La V1 se loge dans ce panneau, **sans introduire de panneau droit**.
+
+Une refonte plus large des panneaux est en cours par Jonathan et Olivier. Notre V1 doit rester **compatible avec leur travail** et **ne pas dépendre de leurs livrables**. Si la nouvelle architecture 3 colonnes arrive en cours de chantier, on s'y adaptera, mais on ne l'attend pas.
+
+### Modèle de données
+
+Sur le modèle Mongoose `Image` (à adapter selon le nom réel) :
+
+```js
+{
+  // existant - inchangé
+  ...
+
+  // nouveau
+  label: String,              // libellé d'affichage (distinct du nom de fichier technique)
+  source: String,             // default: 'upload'
+  externalMetadata: Mixed,    // default: {}
+}
+```
+
+**Aucun champ existant ne doit être modifié ou retiré.**
+
+Index Mongo à ajouter pour les performances de recherche/filtre :
+
+- `templateId + label` (recherche)
+- `templateId + format` (filtre type)
+- `templateId + createdAt` (tri date)
+
+---
+
+## 6. Stack technique
+
+| Couche        | Techno                                              |
+| ------------- | --------------------------------------------------- |
+| Front         | Vue 2.6.14 + Nuxt 2.17 + Vuetify 1.12               |
+| State         | Vuex 3.6                                            |
+| Back          | Express 4.17 + Mongoose 5.13                        |
+| DB            | MongoDB 4.2                                         |
+| Stockage      | FS local OU AWS S3                                  |
+| Images        | Sharp 0.33                                          |
+| Éditeur img   | Konva 9.3 (existant, à ne PAS toucher)              |
+| Éditeur email | Mosaico (fork Badsender)                            |
+| Tests         | Jest + Cypress                                      |
+| Lint          | ESLint (standard + vue/recommended)                 |
+| Format        | Prettier (2 spaces, single quotes)                  |
+| Node          | 18.18.0 (`.nvmrc`)                                  |
+| Yarn          | Classic (< v2)                                      |
+| Monorepo      | `packages/server`, `packages/ui`, `packages/editor` |
+
+**Conventions critiques** :
+
+- Pas de TypeScript (JS only)
+- Pas de migration de versions Vue/Vuetify dans ce projet
+- Rester cohérent avec l'existant
+
+---
+
+## 7. Risques techniques identifiés
+
+⚠️ **Points à investiguer en priorité** avant tout dev :
+
+1. **Mosaico** : l'API images existante doit rester compatible. C'est la zone la plus risquée. Avant toute modif du modèle de données ou des endpoints, **comprendre exactement comment Mosaico consomme les images** (US-00).
+2. **Vue 2 / Vuetify 1.12** : versions anciennes (Vue 2 en fin de vie). Pas de migration prévue. Choisir des composants/libs compatibles.
+3. **Performance** : galeries de plusieurs centaines d'images chez gros clients (Clarins ~300 utilisateurs, 18 marchés, un template). Virtualisation front + indexation Mongo indispensables.
+4. **Comportement asymétrique upload existant** : upload dans la galerie → déclenche l'éditeur Konva. Upload direct dans l'email → resize auto. **À PRÉSERVER ABSOLUMENT.**
+
+---
+
+## 8. Conventions de travail
+
+### Branches
+
+- Branche de départ : `develop`
+- Branches de feature : `feat/gallery-redesign-XXX` où XXX est l'identifiant court de l'US (ex: `feat/gallery-redesign-data-model`)
+- **Ne PAS** travailler sur `develop` directement
+- **Une PR par US** (option B validée avec le PO)
+
+### Commits
+
+Style observé sur les branches récentes : préfixes `feat:`, `fix:`, `chore:`, `docs:` (Conventional Commits probable, à confirmer à l'exploration du repo).
+
+### Pull Requests
+
+- Description claire avec :
+  - Lien vers l'US correspondante (`USER_STORIES.md`)
+  - Liste des changements
+  - Comment tester
+  - Captures d'écran si UI
+- Reviewer assigné : à définir avec le PO
+- Merger uniquement après review + tests passants
+
+### Tests
+
+- **Jest** : tests unitaires pour tout nouveau service backend et tout nouvel endpoint API
+- **Cypress** : 1 à 2 tests E2E par PR sur les parcours critiques (recherche, filtre, édition d'image, renommage…)
+- **Test de non-régression Mosaico** : à chaque PR qui touche le modèle d'image ou les endpoints, vérifier que l'éditeur email fonctionne toujours
+
+### Migration des données
+
+- Script Node.js dans `packages/server/scripts/`
+- Idempotent (relançable sans dommage)
+- Resumable (reprend là où il s'est arrêté)
+- Mode `--dry-run` obligatoire
+- Logs progressifs
+- Lancé manuellement, hors heures de bureau
+
+---
+
+## 9. Découpage en User Stories
+
+Voir le fichier dédié : **`docs/gallery-redesign/USER_STORIES.md`**
+
+Ordre de priorité (à suivre sauf décision contraire) :
+
+1. **Investigation Mosaico** (spike) — 1 jour
+2. **Modèle de données** : libellé, source, externalMetadata
+3. **API backend** : recherche, filtres, renommage
+4. **Script de migration** des thumbnails et libellés
+5. **Refonte grille panneau gauche** : vignettes, libellé, overlay, upload, compteur, virtualisation, damier, tooltip
+6. **Action Éditer** depuis la galerie (intégration Konva sur image existante)
+7. **Polissage**
+
+Estimation totale : **5 à 7 jours-développeur**, soit **1.5 à 2 semaines** en calendrier.
+
+---
+
+## 10. Références visuelles
+
+Maquettes HTML statiques en référence (à ouvrir dans un navigateur) :
+
+- **`docs/gallery-redesign/mockup-v1.html`** : première itération, galerie en panneau gauche unique. **C'est la référence visuelle la plus proche du périmètre V1**, car elle n'a pas de panneau droit. Note : elle inclut des éléments hors scope V1 (collections, bulk) qu'il faut ignorer.
+- **`docs/gallery-redesign/mockup-v2.html`** : itération avec architecture split gauche/droite. **Référence pour la V2 future**, à ne pas implémenter dans la V1.
+
+Points de design importants à respecter pour la V1 :
+
+- **Damier** sur les fonds d'images transparentes (PNG, GIF). Pattern classique 12px gris clair / blanc.
+- **Vignettes carrées** standardisées via Sharp, libellé en bas de chaque vignette
+- **Overlay au survol** avec 2 actions seulement dans la V1 : **Éditer / Supprimer**
+- **Tooltip** au survol prolongé avec libellé / dimensions / format / date
+- **Palette** : navy `#0d3b4f`, cyan `#1bb5d6`, cyan soft `#e6f7fb`, gris neutre
+
+---
+
+## 11. Definition of Done (par US)
+
+Une US est considérée terminée si :
+
+- [ ] Code écrit et fonctionnel
+- [ ] Tests Jest (back) et/ou Cypress (front) écrits et passants
+- [ ] Lint et Prettier passent
+- [ ] Pas de régression Mosaico (vérification manuelle ou automatisée)
+- [ ] PR ouverte avec description claire
+- [ ] Review validée
+- [ ] Mergée dans `develop`
+
+---
+
+## 12. Comment travailler avec Claude Code sur ce chantier
+
+À ton démarrage en tant que Claude Code dans ce dépôt, commence par :
+
+1. **Lire ce fichier en entier** (déjà fait si tu lis ces lignes)
+2. **Lire `docs/gallery-redesign/USER_STORIES.md`** pour comprendre le découpage détaillé
+3. **Ouvrir les maquettes** `docs/gallery-redesign/mockup-v1.html` (référence V1) — note : mockup-v2.html est la cible V2, à ignorer pour cette phase
+4. **Explorer le code existant** :
+   - `packages/server/` pour comprendre la structure backend
+   - `packages/ui/` pour comprendre les composants Vue existants
+   - Chercher les fichiers actuels liés aux images (modèle Mongoose, endpoints, composants gallerie)
+5. **Surveiller la branche `feat/unified-sidebar`** (travail de Jonathan/Olivier sur les panneaux) pour éviter les conflits
+6. **Demander au PO** la prochaine US à attaquer (ou prendre la suivante dans l'ordre de priorité)
+7. **Avant tout dev**, présenter au PO un plan d'attaque pour l'US :
+   - Fichiers à créer/modifier
+   - Stratégie de test
+   - Risques identifiés
+   - Estimation de temps
+
+**Règles d'or** :
+
+- Ne JAMAIS toucher au code de Mosaico (`packages/editor/`) sans validation explicite du PO
+- Tout changement sur le modèle d'image doit préserver la compatibilité avec Mosaico
+- Ne JAMAIS ajouter de fonctionnalités hors scope V1, même si elles semblent évidentes (collections, soft delete, bulk, etc.). Elles sont reportées explicitement.
+- En cas de doute sur le scope, demander au PO.
+
+---
+
+_Dernière mise à jour : juin 2026 — version V1 (périmètre resserré après alignement avec Jonathan)._

--- a/docs/gallery-redesign/README.md
+++ b/docs/gallery-redesign/README.md
@@ -1,0 +1,132 @@
+# Pack de transfert — Refonte galerie LePatron (MVP V1)
+
+Ce dossier contient tout ce qu'il faut pour démarrer le développement de la **V1 de la refonte galerie** avec Claude Code.
+
+> ⚠️ **Important** : ce pack reflète le **périmètre V1 resserré** après alignement avec Jonathan.
+> Beaucoup de fonctionnalités initialement envisagées (collections, panneau droit, bulk, soft delete)
+> sont explicitement reportées en V2+. Lire `CLAUDE.md` section 3 et 4 pour les détails.
+
+## Contenu
+
+- **`CLAUDE.md`** — Fichier de contexte principal, lu automatiquement par Claude Code à chaque session
+- **`USER_STORIES.md`** — Découpage opérationnel en 7 user stories priorisées (V1 uniquement)
+- **`mockup-v1.html`** — Première maquette, galerie en panneau gauche unique. **Référence visuelle V1.**
+- **`mockup-v2.html`** — Maquette avec architecture split gauche/droite. **Cible V2 future, à ne pas implémenter dans la V1.**
+
+## Périmètre V1 (rappel rapide)
+
+**INCLUS** :
+
+- Refonte UI grille (vignettes, libellés, overlay, damier, upload compact, scroll virtualisé)
+- Recherche par libellé
+- Filtres : type de fichier, date
+- Actions : Éditer (Konva), Renommer (libellé), Supprimer (ISO existant), Télécharger (ISO existant)
+- Tooltip au survol
+- Migration des données existantes
+
+**HORS SCOPE V1 (V2+)** :
+
+- Panneau droit
+- Collections
+- Sélection multiple / bulk actions
+- Soft delete / corbeille
+- Mode Détails enrichi
+- Indicateur d'usage
+- Avertissement à la suppression
+
+**Estimation** : ~8.5 à 9 jours-développeur, soit 2 à 3 semaines en calendrier.
+
+## Installation dans le dépôt LePatron.email
+
+### 1. Cloner le dépôt et passer sur develop
+
+```bash
+git clone git@github.com:Badsender-com/LePatron.email.git
+cd LePatron.email
+git checkout develop
+git pull
+```
+
+### 2. Créer la structure de documentation
+
+```bash
+mkdir -p docs/gallery-redesign
+```
+
+### 3. Copier les fichiers du pack
+
+Place les fichiers de ce pack aux emplacements suivants dans ton dépôt :
+
+| Fichier source    | Destination dans le dépôt               |
+| ----------------- | --------------------------------------- |
+| `CLAUDE.md`       | `CLAUDE.md` (à la racine du dépôt)      |
+| `USER_STORIES.md` | `docs/gallery-redesign/USER_STORIES.md` |
+| `mockup-v1.html`  | `docs/gallery-redesign/mockup-v1.html`  |
+| `mockup-v2.html`  | `docs/gallery-redesign/mockup-v2.html`  |
+
+⚠️ **Attention** : il y a probablement déjà un `CLAUDE.md` à la racine si Bearstudio en a mis un (la branche `chore/migrate-claude-commands-to-claude-skills` le suggère). Dans ce cas, ne pas écraser ! Soit :
+
+- Renommer notre fichier en `CLAUDE.gallery.md` à la racine
+- Soit intégrer notre contenu en bas du fichier existant dans une section dédiée `## Refonte galerie d'images V1`
+
+### 4. Créer une branche dédiée pour la documentation
+
+```bash
+git checkout -b chore/gallery-redesign-docs
+git add CLAUDE.md docs/gallery-redesign/
+git commit -m "docs: setup gallery redesign V1 project structure and references"
+git push -u origin chore/gallery-redesign-docs
+```
+
+Ouvre une PR pour valider l'intégration de la doc dans `develop` avant de commencer le dev.
+
+### 5. Démarrer Claude Code
+
+Une fois la PR mergée (ou en parallèle sur la branche, peu importe) :
+
+```bash
+cd LePatron.email
+claude
+```
+
+Au premier prompt, dis à Claude Code :
+
+> Lis le fichier CLAUDE.md à la racine du dépôt, puis docs/gallery-redesign/USER_STORIES.md. On va démarrer le chantier de refonte de la galerie d'images, version V1. Avant d'attaquer l'US-00, explore brièvement le dépôt pour me confirmer la structure du monorepo et identifier les fichiers liés aux images (modèle Mongoose, endpoints, composants Vue). Donne-moi un état des lieux en 10-15 lignes maximum.
+
+Claude Code prendra le contexte et te proposera un état des lieux, puis on attaquera l'US-00 (spike Mosaico).
+
+## Workflow recommandé pour chaque US
+
+1. **Lire** l'US dans `USER_STORIES.md`
+2. **Demander un plan** à Claude Code avant tout dev (fichiers impactés, stratégie de test, risques)
+3. **Valider le plan** ensemble
+4. **Créer la branche** : `git checkout -b feat/gallery-redesign-XX-nom-court`
+5. **Implémenter** (en plusieurs allers-retours avec Claude Code)
+6. **Tester** localement
+7. **Commit + push + PR**
+8. **Review** (par toi ou un reviewer)
+9. **Merge** dans develop
+10. **Tester sur l'env de test**
+
+## Si tu hésites ou si tu sens Claude Code dériver
+
+Quelques prompts utiles :
+
+- "Relis CLAUDE.md, j'ai l'impression qu'on s'éloigne du périmètre V1."
+- "Cette fonctionnalité est-elle bien dans le périmètre V1 d'après CLAUDE.md ? Si non, on l'écarte."
+- "Avant de continuer, fais un point sur l'avancement de l'US courante et ce qu'il reste à faire."
+
+## Garde-fou anti-dérive de scope
+
+Le piège principal de ce chantier : **ajouter des fonctionnalités "au passage" qui semblent évidentes**. Par exemple : "tant qu'on fait la suppression, autant ajouter la corbeille". NON. Le périmètre V1 est volontairement serré. Si une idée semble pertinente mais hors scope V1, **note-la pour la V2** mais ne l'implémente pas.
+
+## Contacts
+
+- PO du chantier : toi
+- Refonte panneau gauche (en parallèle) : Olivier
+- Refonte interface globale (panneau droit etc.) : Jonathan
+- À surveiller : la branche `feat/unified-sidebar` pour éviter les conflits
+
+---
+
+Bonne route ! 🚀

--- a/docs/gallery-redesign/USER_STORIES.md
+++ b/docs/gallery-redesign/USER_STORIES.md
@@ -1,0 +1,260 @@
+# User Stories — Refonte galerie d'images (MVP V1)
+
+> Découpage opérationnel pour Claude Code et l'équipe.
+> Chaque US = une PR à part (option B validée).
+> Estimations en jours-développeur ; à ajuster selon ressources.
+>
+> **Périmètre V1 resserré** : améliorer l'existant sans introduire de nouveaux concepts produit.
+> Les fonctionnalités plus ambitieuses (collections, panneau droit, bulk, soft delete) sont
+> reportées en V2+ — voir `CLAUDE.md` section 4.
+
+---
+
+## Légende
+
+- 🔴 **Critique** : bloquant pour la suite
+- 🟡 **Majeur** : fonctionnalité MVP
+- 🟢 **Polissage** : amélioration
+
+- ⏱ Estimation
+- ⚠ Risques / points de vigilance
+- 🧪 Stratégie de test
+
+---
+
+## US-00 — Spike : investigation Mosaico 🔴
+
+**Objectif** : comprendre exactement comment Mosaico interagit avec les images de LePatron, avant de toucher au modèle de données ou aux endpoints.
+
+**Tâches** :
+
+- Lire le code de l'intégration Mosaico dans `packages/editor/`
+- Identifier les endpoints API consommés par Mosaico pour les images (upload, list, delete…)
+- Identifier le format de réponse attendu par Mosaico
+- Lister les champs d'image utilisés par Mosaico (id, url, dimensions…)
+- Documenter dans un fichier `docs/gallery-redesign/MOSAICO_COMPAT.md` les contraintes à respecter
+
+**Livrable** : document Markdown listant les contraintes Mosaico.
+
+⏱ 1 jour
+⚠ Si on ne fait pas ce spike, on risque de casser l'éditeur email à la première modif. Investissement essentiel.
+🧪 Pas de tests automatisés, mais une PR "documentation" mergée dans develop.
+
+---
+
+## US-01 — Modèle de données : extensions du schéma Image 🔴
+
+**Objectif** : faire évoluer le modèle Mongoose `Image` pour ajouter les champs nécessaires à la V1, **sans casser la compatibilité Mosaico**.
+
+**Tâches** :
+
+- Ajouter le champ `label` (libellé d'affichage, distinct du nom de fichier technique)
+  - Par défaut, à l'upload, `label = nom de fichier original` (avant renommage technique)
+- Ajouter le champ `source` (String, default `upload`)
+- Ajouter le champ `externalMetadata` (Mixed, default `{}`)
+- **Aucune modification ni suppression de champ existant**
+- Ajouter les index Mongo nécessaires :
+  - `templateId + label` (recherche)
+  - `templateId + format` (filtre type)
+  - `templateId + createdAt` (tri date)
+- Adapter les sérializeurs API pour exposer ces nouveaux champs aux nouveaux endpoints, sans les exposer aux endpoints consommés par Mosaico (à valider via US-00)
+
+⏱ 0.5 jour
+⚠ La compat Mosaico est cruciale : ne pas modifier les champs existants. Voir US-00.
+🧪 Tests unitaires Jest sur le modèle (validation, defaults, virtuals).
+
+**Hors scope V1** :
+
+- ❌ `deletedAt` / soft delete (reporté V2)
+- ❌ Relation Image ↔ Collection (reporté V2, pas de collections en V1)
+
+---
+
+## US-02 — API backend : recherche, filtres, renommage 🔴
+
+**Objectif** : enrichir l'endpoint de liste d'images existant pour supporter recherche et filtres, et ajouter un endpoint de renommage.
+
+**Endpoints à modifier ou créer** :
+
+- `GET /api/templates/:templateId/images` (modification) :
+  - Filtres : `?search=`, `?format=jpg|png|gif`, `?sortBy=date_desc|date_asc`
+  - Pagination/curseur pour scroll virtualisé
+  - La normalisation du paramètre `format` doit gérer toutes les variantes de casse (JPG, jpg, JpG…) et matcher JPG ET JPEG pour le filtre "JPG"
+- `PATCH /api/images/:id/label` (nouveau) :
+  - Modifier le libellé d'une image
+  - Le nom de fichier technique reste inchangé
+
+**Compat Mosaico** : tous les endpoints existants utilisés par Mosaico doivent rester compatibles (voir US-00). Si nécessaire, dupliquer un endpoint plutôt que modifier celui consommé par Mosaico.
+
+⏱ 1 jour
+⚠ Préserver la compat Mosaico. Performance de recherche : utiliser un index Mongo sur `label`.
+🧪 Tests Jest sur chaque endpoint (cas nominal + cas d'erreur). Test sur les variantes de casse du filtre format.
+
+**Hors scope V1** :
+
+- ❌ Endpoints de soft delete / restore / corbeille (reporté V2)
+- ❌ Endpoints de collections (reporté V2)
+- ❌ Endpoints de bulk (reporté V2)
+- ❌ Endpoint d'usage `?usedIn` (reporté V2)
+
+---
+
+## US-03 — Script de migration des données existantes 🔴
+
+**Objectif** : migrer les images existantes vers le nouveau modèle, sans interruption de service.
+
+**Tâches** :
+
+- Script `packages/server/scripts/migrate-gallery-v1.js`
+- Pour chaque image existante :
+  - Initialiser `label` à partir du nom de fichier original (ou nom technique si non disponible)
+  - Initialiser `source = 'upload'`
+  - Initialiser `externalMetadata = {}`
+  - Régénérer les thumbnails standardisés via Sharp si nécessaire
+- Propriétés :
+  - **Idempotent** : skip les images déjà migrées (`label` non vide = skip)
+  - **Resumable** : reprend là où il s'est arrêté (via curseur ou checkpoint)
+  - **Dry-run** : option `--dry-run`
+  - **Batched** : traite par lots de 100 images
+  - **Logs progressifs** : `[1234/5678] Migrée image XYZ`
+- Documentation d'utilisation dans `packages/server/scripts/README.md`
+
+⏱ 1 jour
+⚠ Tester sur un dump de prod avant de lancer en réel. Prévoir une fenêtre de maintenance pour le run réel.
+🧪 Tests Jest unitaires sur les fonctions de migration. Un test E2E sur un dataset de 10 images mock.
+
+---
+
+## US-04 — Refonte de la grille galerie (panneau gauche) 🟡
+
+**Objectif** : remplacer l'UI actuelle de la galerie par la nouvelle version. **Sans introduire de panneau droit, sans collections, sans sélection multiple.**
+
+**Tâches** :
+
+- Composant `GalleryPanel.vue` (ou équivalent, nom à valider à l'exploration) qui contient :
+  - Onglets `Spécifique à l'email` / `Commun au template` (inchangés)
+  - Barre de recherche (debounce 300ms, requête API avec `?search=`)
+  - Filtres rapides (JPG/PNG/GIF) → requête API avec `?format=`
+  - Filtres rapides date (récent/ancien) → requête API avec `?sortBy=`
+  - Zone d'upload compacte (réduite quand des images existent — drag & drop + clic)
+  - Grille virtualisée (lib type `vue-virtual-scroller` ou équivalent compatible Vue 2 / Vuetify 1.12)
+  - Compteur d'images
+- Composant `Thumb.vue` (ou équivalent) :
+  - Vignette carrée
+  - Damier si fond transparent (PNG/GIF), fond uni si JPG
+  - Libellé sous la vignette (tronqué avec ellipsis si trop long)
+  - Badge GIF si applicable
+  - Tooltip au survol prolongé : libellé complet, dimensions, format, date d'upload
+  - Overlay au survol avec 2 actions : **Éditer** / **Supprimer**
+    - L'action "Renommer" peut être déclenchée par un double-clic sur le libellé (interaction subtile, pas dans l'overlay)
+    - Ou via menu contextuel ⋯ — à arbitrer en cours de dev
+- Empty state quand 0 image (galerie vide, recherche sans résultat, filtre sans résultat)
+
+**Hors scope dans cette US** :
+
+- ❌ Panneau droit (reporté V2)
+- ❌ Mode Détails (reporté V2)
+- ❌ Sélection multiple, checkboxes, bulk (reporté V2)
+- ❌ Action "Collections" dans l'overlay (reporté V2)
+- ❌ Avertissement à la suppression (décision produit : ISO existant)
+
+⏱ 2.5 jours
+🧪 Cypress : ouverture galerie, recherche d'une image, filtre par format, filtre par date, upload d'une image, survol d'une vignette pour voir le tooltip, ouverture de l'overlay.
+
+---
+
+## US-05 — Action Éditer depuis la galerie 🟡
+
+**Objectif** : pouvoir relancer l'éditeur Konva sur une image déjà uploadée.
+
+**Tâches** :
+
+- Identifier le composant existant qui lance l'éditeur Konva lors d'un upload
+- Créer un point d'entrée pour relancer cet éditeur sur une image existante :
+  - Charger l'image source depuis le storage (FS ou S3)
+  - Ouvrir l'éditeur Konva avec cette image
+  - À la sauvegarde : remplacer l'image originale (pas de nouvelle version dans la V1)
+- Brancher depuis l'action "Éditer" de l'overlay au survol d'une vignette
+- À la sauvegarde, mettre à jour le thumbnail et invalider le cache front si nécessaire
+
+**Décision produit confirmée** : on **remplace** l'image originale (plus simple, conforme au comportement actuel d'upload). L'historique des versions est explicitement reporté.
+
+⏱ 1.5 jour
+⚠ Konva est explicitement hors scope de modifications. On l'utilise, on ne le modifie pas. Vérifier que la sauvegarde régénère bien le thumbnail Sharp.
+🧪 Cypress : ouvrir une image existante dans l'éditeur, modifier, sauvegarder, vérifier que la vignette est mise à jour.
+
+---
+
+## US-06 — Action Renommer le libellé 🟡
+
+**Objectif** : permettre de renommer le libellé d'une image (le nom de fichier technique reste inchangé).
+
+**Tâches** :
+
+- Implémenter l'UI de renommage : **double-clic sur le libellé sous la vignette → champ inline éditable** (style Figma / Finder / Notion)
+  - Valider par Entrée ou perte de focus
+  - Annuler par Échap
+  - Sélectionner tout le texte à l'entrée en mode édition (UX standard)
+- Appel à l'endpoint `PATCH /api/images/:id/label`
+- Mise à jour optimiste dans l'UI
+- Gestion d'erreur (si le libellé est vide, trop long, ou en erreur réseau)
+
+**Fallback si la solution s'avère complexe à implémenter proprement** : menu contextuel `⋯` sur la vignette → "Renommer" → input ou petite modale. À ne mobiliser qu'en dernier recours, avec validation du PO.
+
+⏱ 0.5 jour
+🧪 Cypress : renommer une image, vérifier l'affichage, vérifier la persistence après refresh.
+
+---
+
+## US-07 — Polissage 🟢
+
+**Objectif** : finaliser les détails qui font la différence côté UX.
+
+**Tâches** :
+
+- Animations légères (apparition de l'overlay, transitions)
+- États vides soignés (galerie vide, recherche sans résultat)
+- Accessibilité de base (rôles ARIA, focus visible, navigation clavier)
+- Gestion des erreurs (upload qui échoue, network error, timeout)
+- Tooltips sur les icônes au survol prolongé
+- Loading states (squelettes pendant le chargement de la grille)
+- Cohérence visuelle finale avec le design system LePatron (validation avec Jonathan/Olivier)
+- Tests de non-régression sur l'ensemble du flux
+- Vérification finale de la compat Mosaico (test manuel : upload, édition d'email avec images, export)
+
+⏱ 0.5 à 1 jour
+🧪 Cypress sur les états vides, les erreurs réseau (avec interception). Test manuel Mosaico complet.
+
+---
+
+## Total estimé
+
+| Phase          | US                  | Jours              |
+| -------------- | ------------------- | ------------------ |
+| Investigation  | US-00               | 1                  |
+| Backend & data | US-01 à US-03       | 2.5                |
+| UI             | US-04, US-05, US-06 | 4.5                |
+| Polissage      | US-07               | 0.5 - 1            |
+| **TOTAL V1**   |                     | **~8.5 à 9 jours** |
+
+À ajouter : temps de review, allers-retours, intégration continue, débuggage en environnement de test. Compter probablement **2 à 3 semaines de calendrier** pour une exécution sereine à 1 développeur.
+
+---
+
+## V2 — Prévisualisation du périmètre suivant
+
+À titre indicatif, la V2 ajoutera probablement, dans l'ordre :
+
+1. Architecture 3 colonnes (panneau droit dédié)
+2. Mode Détails dans le panneau droit (preview enrichie, métadonnées étendues, usage)
+3. Soft delete + corbeille 30j + UI de restauration
+4. Collections (création, gestion, navigation, vue "Non classées")
+5. Sélection multiple + bulk actions
+6. Indicateur d'usage généralisé
+7. Avertissement à la suppression
+
+L'estimation V2 sera à faire au moment venu, en intégrant les retours utilisateurs sur la V1.
+
+---
+
+_Ce découpage est indicatif. À ajuster en cours de chantier selon les découvertes, les retours de review, et les priorités du PO._

--- a/docs/gallery-redesign/mockup-v1.html
+++ b/docs/gallery-redesign/mockup-v1.html
@@ -1,0 +1,1528 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LePatron — Galerie refondue (maquette)</title>
+<style>
+  /* =========================================================
+     DESIGN TOKENS — alignés sur le design system LePatron
+     ========================================================= */
+  :root {
+    /* Palette — inspirée des captures fournies */
+    --lp-navy: #0d3b4f;         /* header sombre */
+    --lp-navy-hover: #0a2d3d;
+    --lp-cyan: #1bb5d6;         /* accent principal */
+    --lp-cyan-dark: #0f94b0;
+    --lp-cyan-soft: #e6f7fb;
+    --lp-bg: #f5f3ef;           /* fond général */
+    --lp-panel: #ffffff;
+    --lp-panel-alt: #faf9f6;
+    --lp-border: #e2e1dd;
+    --lp-border-strong: #c9c7c1;
+    --lp-text: #1e2a2f;
+    --lp-text-muted: #6b7478;
+    --lp-text-faint: #9aa1a4;
+    --lp-danger: #d84a3a;
+    --lp-danger-soft: #fdeceb;
+    --lp-success: #3a9b6b;
+    --lp-warning: #e8a93a;
+
+    /* Géométrie */
+    --lp-radius-sm: 4px;
+    --lp-radius: 6px;
+    --lp-radius-lg: 10px;
+
+    /* Ombres */
+    --lp-shadow-sm: 0 1px 2px rgba(13, 59, 79, 0.06);
+    --lp-shadow: 0 2px 8px rgba(13, 59, 79, 0.08);
+    --lp-shadow-lg: 0 8px 24px rgba(13, 59, 79, 0.12);
+
+    /* Panneau galerie — 364px utile */
+    --panel-width: 400px;
+    --panel-padding: 18px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    color: var(--lp-text);
+    background: var(--lp-bg);
+    height: 100vh;
+    overflow: hidden;
+    font-size: 14px;
+    line-height: 1.4;
+  }
+
+  /* =========================================================
+     LAYOUT GLOBAL — reproduit l'environnement LePatron
+     ========================================================= */
+  .app {
+    display: grid;
+    grid-template-rows: 52px 1fr;
+    height: 100vh;
+  }
+
+  /* Header du haut */
+  .header {
+    background: var(--lp-navy);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    gap: 16px;
+  }
+  .header-left { display: flex; align-items: center; gap: 12px; }
+  .header-title {
+    flex: 1;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    opacity: 0.9;
+  }
+  .header-right { display: flex; align-items: center; gap: 4px; }
+  .header-btn {
+    width: 34px;
+    height: 34px;
+    border: none;
+    background: transparent;
+    color: #fff;
+    opacity: 0.75;
+    cursor: pointer;
+    border-radius: var(--lp-radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+  }
+  .header-btn:hover { opacity: 1; background: rgba(255,255,255,0.08); }
+  .header-btn.active {
+    background: var(--lp-cyan);
+    opacity: 1;
+  }
+  .header-btn svg { width: 18px; height: 18px; }
+  .header-save {
+    background: transparent;
+    color: #fff;
+    border: none;
+    padding: 6px 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    opacity: 0.9;
+  }
+  .header-save:hover { opacity: 1; }
+
+  .main {
+    display: grid;
+    grid-template-columns: var(--panel-width) 1fr;
+    overflow: hidden;
+  }
+
+  /* =========================================================
+     PANNEAU GALERIE — le cœur de la refonte
+     ========================================================= */
+  .gallery {
+    background: var(--lp-panel);
+    border-right: 1px solid var(--lp-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Barre de titre du panneau */
+  .gallery-header {
+    padding: 14px var(--panel-padding) 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+  }
+  .gallery-title {
+    color: var(--lp-cyan);
+    font-size: 18px;
+    font-weight: 500;
+    letter-spacing: 0.2px;
+  }
+  .gallery-close {
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: transparent;
+    color: var(--lp-cyan);
+    cursor: pointer;
+    border-radius: var(--lp-radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+  }
+  .gallery-close:hover { background: var(--lp-cyan-soft); }
+  .gallery-close svg { width: 16px; height: 16px; }
+
+  /* Onglets */
+  .tabs {
+    display: flex;
+    border-bottom: 1px solid var(--lp-border);
+    margin-top: 12px;
+  }
+  .tab {
+    flex: 1;
+    padding: 12px 8px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.3px;
+    text-transform: uppercase;
+    color: var(--lp-text-muted);
+    border-bottom: 2px solid transparent;
+    transition: all 0.15s;
+    font-family: inherit;
+  }
+  .tab:hover { color: var(--lp-text); }
+  .tab.active {
+    color: var(--lp-navy);
+    border-bottom-color: var(--lp-cyan);
+  }
+
+  /* Toolbar recherche + filtres */
+  .toolbar {
+    padding: 12px var(--panel-padding) 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    border-bottom: 1px solid var(--lp-border);
+  }
+
+  .search {
+    position: relative;
+  }
+  .search input {
+    width: 100%;
+    padding: 8px 12px 8px 34px;
+    border: 1px solid var(--lp-border-strong);
+    border-radius: var(--lp-radius);
+    font-size: 13px;
+    background: var(--lp-panel-alt);
+    font-family: inherit;
+    color: var(--lp-text);
+    transition: all 0.15s;
+  }
+  .search input:focus {
+    outline: none;
+    border-color: var(--lp-cyan);
+    background: #fff;
+    box-shadow: 0 0 0 3px var(--lp-cyan-soft);
+  }
+  .search svg {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    color: var(--lp-text-faint);
+    pointer-events: none;
+  }
+
+  .filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+  .filter-chip {
+    padding: 4px 10px;
+    border: 1px solid var(--lp-border-strong);
+    border-radius: 14px;
+    background: var(--lp-panel);
+    color: var(--lp-text-muted);
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .filter-chip:hover {
+    border-color: var(--lp-cyan);
+    color: var(--lp-text);
+  }
+  .filter-chip.active {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+    color: #fff;
+  }
+
+  /* Barre collections (uniquement dans commun-template) */
+  .collections-bar {
+    padding: 10px var(--panel-padding);
+    border-bottom: 1px solid var(--lp-border);
+    display: none;
+    flex-direction: column;
+    gap: 8px;
+    background: var(--lp-panel-alt);
+  }
+  .collections-bar.visible { display: flex; }
+
+  .collections-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .collections-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--lp-text-muted);
+  }
+  .collection-new {
+    background: transparent;
+    border: none;
+    color: var(--lp-cyan-dark);
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    padding: 2px 6px;
+    border-radius: var(--lp-radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+  }
+  .collection-new:hover { background: var(--lp-cyan-soft); }
+
+  .collection-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+  .collection-pill {
+    padding: 5px 11px;
+    border-radius: 14px;
+    border: 1px solid var(--lp-border-strong);
+    background: var(--lp-panel);
+    color: var(--lp-text);
+    font-size: 12px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+  .collection-pill:hover {
+    border-color: var(--lp-cyan);
+  }
+  .collection-pill.active {
+    background: var(--lp-navy);
+    border-color: var(--lp-navy);
+    color: #fff;
+  }
+  .collection-pill .count {
+    font-size: 10px;
+    opacity: 0.7;
+    font-weight: 500;
+  }
+  .collection-pill.special {
+    font-style: italic;
+    color: var(--lp-text-muted);
+  }
+  .collection-pill.special.active {
+    color: #fff;
+    font-style: italic;
+  }
+
+  /* Zone d'upload compacte */
+  .upload-zone {
+    margin: 10px var(--panel-padding);
+    padding: 8px 12px;
+    border: 1.5px dashed var(--lp-border-strong);
+    border-radius: var(--lp-radius);
+    text-align: center;
+    cursor: pointer;
+    font-size: 12px;
+    color: var(--lp-text-muted);
+    background: var(--lp-panel-alt);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: all 0.15s;
+  }
+  .upload-zone:hover {
+    border-color: var(--lp-cyan);
+    color: var(--lp-cyan-dark);
+    background: var(--lp-cyan-soft);
+  }
+  .upload-zone svg { width: 14px; height: 14px; }
+
+  /* Compteur + sélection mode */
+  .gallery-meta {
+    padding: 0 var(--panel-padding) 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 11px;
+    color: var(--lp-text-muted);
+  }
+  .meta-count { font-weight: 500; }
+  .meta-actions {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+  }
+  .meta-link {
+    background: none;
+    border: none;
+    color: var(--lp-cyan-dark);
+    cursor: pointer;
+    font-size: 11px;
+    font-family: inherit;
+    padding: 0;
+  }
+  .meta-link:hover { text-decoration: underline; }
+
+  /* Bulk actions bar (quand sélection active) */
+  .bulk-bar {
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px var(--panel-padding);
+    background: var(--lp-navy);
+    color: #fff;
+    font-size: 12px;
+  }
+  .bulk-bar.visible { display: flex; }
+  .bulk-count { font-weight: 500; }
+  .bulk-actions { display: flex; gap: 4px; }
+  .bulk-btn {
+    background: rgba(255,255,255,0.1);
+    border: none;
+    color: #fff;
+    padding: 5px 10px;
+    border-radius: var(--lp-radius-sm);
+    cursor: pointer;
+    font-size: 12px;
+    font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: background 0.15s;
+  }
+  .bulk-btn:hover { background: rgba(255,255,255,0.2); }
+  .bulk-btn.danger:hover { background: var(--lp-danger); }
+  .bulk-btn svg { width: 13px; height: 13px; }
+
+  /* Grille d'images */
+  .grid-wrap {
+    flex: 1;
+    overflow-y: auto;
+    padding: 6px var(--panel-padding) 16px;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+  }
+
+  .thumb {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    overflow: hidden;
+    cursor: pointer;
+    background: var(--lp-panel-alt);
+    transition: all 0.15s;
+  }
+  .thumb:hover {
+    border-color: var(--lp-cyan);
+    box-shadow: var(--lp-shadow);
+    transform: translateY(-1px);
+  }
+  .thumb.selected {
+    border-color: var(--lp-cyan);
+    border-width: 2px;
+    box-shadow: 0 0 0 2px var(--lp-cyan-soft);
+  }
+  .thumb-img {
+    width: 100%;
+    height: 70%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: #f8f7f3;
+  }
+  .thumb-label {
+    height: 30%;
+    padding: 4px 6px;
+    font-size: 10.5px;
+    color: var(--lp-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
+    background: #fff;
+    border-top: 1px solid var(--lp-border);
+  }
+
+  /* Badge type/GIF */
+  .thumb-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(13, 59, 79, 0.85);
+    color: #fff;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 2px 5px;
+    border-radius: 3px;
+    letter-spacing: 0.3px;
+  }
+  .thumb-badge.gif { background: var(--lp-warning); color: var(--lp-navy); }
+
+  /* Checkbox de sélection */
+  .thumb-check {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: 18px;
+    height: 18px;
+    border-radius: 3px;
+    background: rgba(255,255,255,0.9);
+    border: 1px solid var(--lp-border-strong);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.15s;
+    cursor: pointer;
+    z-index: 3;
+  }
+  .thumb:hover .thumb-check,
+  .thumb.selected .thumb-check,
+  .selection-mode .thumb-check {
+    opacity: 1;
+  }
+  .thumb-check.checked {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+  }
+  .thumb-check svg {
+    width: 12px;
+    height: 12px;
+    color: #fff;
+    display: none;
+  }
+  .thumb-check.checked svg { display: block; }
+
+  /* Overlay d'actions au survol */
+  .thumb-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 0%, transparent 40%, rgba(13,59,79,0.75) 100%);
+    opacity: 0;
+    transition: opacity 0.15s;
+    pointer-events: none;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 6px;
+    z-index: 2;
+  }
+  .thumb:hover .thumb-overlay { opacity: 1; pointer-events: auto; }
+
+  .thumb-actions {
+    display: flex;
+    gap: 3px;
+    background: rgba(255,255,255,0.95);
+    border-radius: var(--lp-radius-sm);
+    padding: 3px;
+    box-shadow: var(--lp-shadow);
+  }
+  .thumb-action {
+    width: 26px;
+    height: 26px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--lp-text);
+    transition: all 0.15s;
+  }
+  .thumb-action:hover {
+    background: var(--lp-cyan-soft);
+    color: var(--lp-cyan-dark);
+  }
+  .thumb-action.danger:hover {
+    background: var(--lp-danger-soft);
+    color: var(--lp-danger);
+  }
+  .thumb-action svg { width: 14px; height: 14px; }
+
+  /* État vide */
+  .empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--lp-text-muted);
+  }
+  .empty-state svg {
+    width: 48px;
+    height: 48px;
+    color: var(--lp-text-faint);
+    margin-bottom: 12px;
+  }
+  .empty-state-title {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--lp-text);
+    margin-bottom: 4px;
+  }
+  .empty-state-msg {
+    font-size: 12px;
+    line-height: 1.5;
+  }
+
+  /* =========================================================
+     ZONE EMAIL À DROITE — reproduction fidèle du contexte
+     ========================================================= */
+  .email-canvas {
+    background: var(--lp-bg);
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+  }
+  .email-preview {
+    width: 100%;
+    max-width: 600px;
+    background: #fff;
+    border: 2px solid var(--lp-cyan);
+    border-radius: 4px;
+  }
+  .email-preheader {
+    text-align: center;
+    padding: 8px;
+    font-size: 11px;
+    color: var(--lp-text-muted);
+  }
+  .email-preheader a { color: var(--lp-text-muted); }
+  .email-header-brand {
+    background: #ffd200;
+    padding: 20px;
+    display: flex;
+    justify-content: flex-end;
+  }
+  .email-body {
+    padding: 24px;
+    border: 2px solid #ffd200;
+    margin: 10px;
+    border-radius: 4px;
+  }
+  .email-title {
+    text-align: center;
+    color: #1a3a7a;
+    font-size: 26px;
+    font-weight: 700;
+    margin: 10px 0 20px;
+  }
+  .email-image-slot {
+    background: repeating-linear-gradient(-45deg, #a8a8a8, #a8a8a8 10px, #9c9c9c 10px, #9c9c9c 20px);
+    height: 260px;
+    position: relative;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  .email-image-slot::before {
+    content: "Déposer une image ici";
+    position: absolute;
+    top: 10px;
+    color: #000;
+    font-weight: 700;
+    font-size: 14px;
+  }
+  .email-image-slot span {
+    color: #e0e0e0;
+    font-size: 20px;
+  }
+  .email-text {
+    padding: 18px 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: #333;
+  }
+  .email-button {
+    display: block;
+    width: fit-content;
+    margin: 10px auto;
+    background: #ffd200;
+    color: #1a3a7a;
+    padding: 14px 30px;
+    font-weight: 700;
+    text-decoration: none;
+    border-radius: 3px;
+  }
+  .block-toolbar {
+    background: #fff;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    display: inline-flex;
+    padding: 2px;
+    gap: 2px;
+    box-shadow: var(--lp-shadow);
+    margin: 8px;
+    position: absolute;
+  }
+  .block-toolbar button {
+    width: 28px; height: 28px;
+    border: none; background: transparent;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--lp-text-muted);
+    border-radius: 3px;
+  }
+  .block-toolbar button:hover { background: var(--lp-cyan-soft); color: var(--lp-cyan-dark); }
+  .block-toolbar button svg { width: 14px; height: 14px; }
+
+  /* =========================================================
+     PANNEAU DE DÉTAIL (modale latérale)
+     ========================================================= */
+  .detail-panel {
+    position: fixed;
+    top: 52px;
+    right: -400px;
+    bottom: 0;
+    width: 360px;
+    background: #fff;
+    border-left: 1px solid var(--lp-border);
+    box-shadow: var(--lp-shadow-lg);
+    transition: right 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+  }
+  .detail-panel.visible { right: 0; }
+  .detail-head {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--lp-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .detail-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--lp-navy);
+  }
+  .detail-close {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--lp-text-muted);
+    width: 28px; height: 28px;
+    border-radius: var(--lp-radius-sm);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .detail-close:hover { background: var(--lp-bg); }
+  .detail-body { padding: 20px; overflow-y: auto; flex: 1; }
+  .detail-preview {
+    aspect-ratio: 1;
+    background: var(--lp-panel-alt);
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    margin-bottom: 16px;
+    display: flex; align-items: center; justify-content: center;
+    overflow: hidden;
+  }
+  .detail-preview img { max-width: 100%; max-height: 100%; }
+  .detail-field {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--lp-border);
+    font-size: 12px;
+  }
+  .detail-field:last-child { border-bottom: none; }
+  .detail-label { color: var(--lp-text-muted); }
+  .detail-value { color: var(--lp-text); font-weight: 500; text-align: right; }
+  .detail-value.usage { color: var(--lp-success); }
+  .detail-value.unused { color: var(--lp-text-faint); font-style: italic; }
+  .detail-collections {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    justify-content: flex-end;
+  }
+  .detail-coll {
+    background: var(--lp-cyan-soft);
+    color: var(--lp-cyan-dark);
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+  }
+  .detail-actions {
+    padding: 16px 20px;
+    border-top: 1px solid var(--lp-border);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .detail-btn {
+    padding: 9px 14px;
+    border: 1px solid var(--lp-border-strong);
+    background: #fff;
+    border-radius: var(--lp-radius);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+    color: var(--lp-text);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    transition: all 0.15s;
+  }
+  .detail-btn:hover {
+    border-color: var(--lp-cyan);
+    color: var(--lp-cyan-dark);
+    background: var(--lp-cyan-soft);
+  }
+  .detail-btn.primary {
+    background: var(--lp-cyan);
+    color: #fff;
+    border-color: var(--lp-cyan);
+  }
+  .detail-btn.primary:hover {
+    background: var(--lp-cyan-dark);
+    color: #fff;
+  }
+  .detail-btn.danger {
+    color: var(--lp-danger);
+    border-color: var(--lp-border-strong);
+  }
+  .detail-btn.danger:hover {
+    background: var(--lp-danger-soft);
+    border-color: var(--lp-danger);
+  }
+  .detail-btn svg { width: 14px; height: 14px; }
+
+  /* =========================================================
+     MODALE gestion collections / confirm suppression
+     ========================================================= */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(13, 59, 79, 0.4);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+  }
+  .modal-backdrop.visible { display: flex; }
+  .modal {
+    background: #fff;
+    border-radius: var(--lp-radius-lg);
+    box-shadow: var(--lp-shadow-lg);
+    width: 420px;
+    max-width: 90vw;
+    overflow: hidden;
+  }
+  .modal-head {
+    padding: 16px 20px;
+    border-bottom: 1px solid var(--lp-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .modal-title { font-size: 15px; font-weight: 600; color: var(--lp-navy); }
+  .modal-body { padding: 18px 20px; font-size: 13px; color: var(--lp-text); }
+  .modal-body p { margin: 0 0 10px; }
+  .modal-footer {
+    padding: 12px 20px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    border-top: 1px solid var(--lp-border);
+    background: var(--lp-panel-alt);
+  }
+  .modal-btn {
+    padding: 8px 14px;
+    border-radius: var(--lp-radius);
+    font-size: 13px;
+    font-family: inherit;
+    cursor: pointer;
+    border: 1px solid var(--lp-border-strong);
+    background: #fff;
+    color: var(--lp-text);
+  }
+  .modal-btn:hover { background: var(--lp-panel-alt); }
+  .modal-btn.primary {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+    color: #fff;
+  }
+  .modal-btn.primary:hover { background: var(--lp-cyan-dark); }
+  .modal-btn.danger {
+    background: var(--lp-danger);
+    border-color: var(--lp-danger);
+    color: #fff;
+  }
+  .modal-btn.danger:hover { background: #b83a2d; }
+
+  .collection-checklist { list-style: none; padding: 0; margin: 0; }
+  .collection-checklist li {
+    padding: 8px 12px;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    font-size: 13px;
+  }
+  .collection-checklist li:hover { background: var(--lp-panel-alt); }
+  .collection-checklist input[type="checkbox"] { accent-color: var(--lp-cyan); }
+  .collection-new-inline {
+    margin-top: 12px;
+    display: flex;
+    gap: 6px;
+  }
+  .collection-new-inline input {
+    flex: 1;
+    padding: 7px 10px;
+    border: 1px solid var(--lp-border-strong);
+    border-radius: var(--lp-radius);
+    font-size: 13px;
+    font-family: inherit;
+  }
+  .collection-new-inline input:focus { outline: none; border-color: var(--lp-cyan); }
+
+  /* Scrollbar discrète */
+  .grid-wrap::-webkit-scrollbar,
+  .detail-body::-webkit-scrollbar,
+  .email-canvas::-webkit-scrollbar { width: 8px; }
+  .grid-wrap::-webkit-scrollbar-thumb,
+  .detail-body::-webkit-scrollbar-thumb,
+  .email-canvas::-webkit-scrollbar-thumb { background: var(--lp-border-strong); border-radius: 4px; }
+
+  /* Tooltip d'info pour la démo */
+  .demo-tip {
+    position: fixed;
+    bottom: 16px;
+    left: 16px;
+    background: var(--lp-navy);
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: var(--lp-radius);
+    font-size: 12px;
+    box-shadow: var(--lp-shadow-lg);
+    z-index: 50;
+    max-width: 340px;
+    line-height: 1.5;
+  }
+  .demo-tip strong { color: var(--lp-cyan); }
+  .demo-tip button {
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.3);
+    color: #fff;
+    padding: 3px 9px;
+    border-radius: 3px;
+    font-size: 11px;
+    margin-top: 6px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .demo-tip button:hover { background: rgba(255,255,255,0.1); }
+</style>
+</head>
+<body>
+
+<div class="app">
+  <!-- ============= HEADER (fidèle à l'existant) ============= -->
+  <header class="header">
+    <div class="header-left">
+      <button class="header-btn" title="Retour">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+      </button>
+      <button class="header-btn" title="Blocs">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+      </button>
+    </div>
+    <div class="header-title">test</div>
+    <div class="header-right">
+      <button class="header-btn" title="Vue desktop">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+      </button>
+      <button class="header-btn" title="Vue mobile">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/></svg>
+      </button>
+      <button class="header-btn active" title="Galerie d'images">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M21 15l-5-5L5 21"/></svg>
+      </button>
+      <button class="header-btn" title="Commentaires">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+      </button>
+      <button class="header-btn" title="Annuler">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+      </button>
+      <span style="color: #fff; opacity: 0.6; font-size: 12px;">(19)</span>
+      <button class="header-btn" title="Rétablir">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+      </button>
+      <button class="header-save">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+        Sauvegarder
+      </button>
+      <button class="header-btn" title="Envoyer">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+      </button>
+    </div>
+  </header>
+
+  <div class="main">
+    <!-- ============= PANNEAU GALERIE (la refonte) ============= -->
+    <aside class="gallery">
+      <div class="gallery-header">
+        <div class="gallery-title">Galeries</div>
+        <button class="gallery-close" title="Fermer">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+        </button>
+      </div>
+
+      <nav class="tabs">
+        <button class="tab" data-tab="email">Spécifique à l'email</button>
+        <button class="tab active" data-tab="template">Commun au template</button>
+      </nav>
+
+      <div class="toolbar">
+        <div class="search">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+          <input type="text" placeholder="Rechercher une image..." id="searchInput">
+        </div>
+        <div class="filters">
+          <button class="filter-chip active" data-filter="all">Tous</button>
+          <button class="filter-chip" data-filter="jpg">JPG</button>
+          <button class="filter-chip" data-filter="png">PNG</button>
+          <button class="filter-chip" data-filter="gif">GIF</button>
+          <button class="filter-chip" data-filter="recent" style="margin-left: auto;">
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+            Récent
+          </button>
+        </div>
+      </div>
+
+      <!-- Collections (visible uniquement en commun au template) -->
+      <div class="collections-bar visible" id="collectionsBar">
+        <div class="collections-head">
+          <span class="collections-label">Collections</span>
+          <button class="collection-new" onclick="showNewCollectionModal()">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg>
+            Nouvelle
+          </button>
+        </div>
+        <div class="collection-list" id="collectionList">
+          <button class="collection-pill active" data-collection="all">Toutes <span class="count">42</span></button>
+          <button class="collection-pill special" data-collection="unclassified">Non classées <span class="count">6</span></button>
+          <button class="collection-pill" data-collection="pictos">Pictos marque <span class="count">12</span></button>
+          <button class="collection-pill" data-collection="soldes">Soldes Printemps 26 <span class="count">8</span></button>
+          <button class="collection-pill" data-collection="hero">Bannières hero <span class="count">5</span></button>
+        </div>
+      </div>
+
+      <div class="upload-zone">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+        Glisser-déposer ou cliquer pour uploader
+      </div>
+
+      <div class="gallery-meta">
+        <span class="meta-count" id="metaCount">42 images</span>
+        <div class="meta-actions">
+          <button class="meta-link" id="selectAllBtn">Tout sélectionner</button>
+        </div>
+      </div>
+
+      <!-- Barre de bulk actions (apparaît en mode sélection) -->
+      <div class="bulk-bar" id="bulkBar">
+        <span class="bulk-count"><span id="bulkCount">3</span> sélectionnée(s)</span>
+        <div class="bulk-actions">
+          <button class="bulk-btn" onclick="showCollectionModal(true)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+            Collections
+          </button>
+          <button class="bulk-btn danger" onclick="showDeleteModal(true)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            Supprimer
+          </button>
+          <button class="bulk-btn" onclick="clearSelection()">Annuler</button>
+        </div>
+      </div>
+
+      <!-- Grille d'images -->
+      <div class="grid-wrap">
+        <div class="grid" id="grid"></div>
+      </div>
+    </aside>
+
+    <!-- ============= ZONE EMAIL (reproduction du contexte) ============= -->
+    <section class="email-canvas">
+      <div class="email-preview">
+        <div class="email-preheader">Preheader<br><a href="#">Voir la version en ligne</a></div>
+        <div class="email-header-brand">
+          <div style="background: #1a3a7a; color: #fff; padding: 8px 16px; font-weight: 700; letter-spacing: 1px; font-size: 13px;">LA POSTE</div>
+        </div>
+        <div class="email-body" style="position: relative;">
+          <div class="block-toolbar">
+            <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="5" cy="5" r="1"/><circle cx="5" cy="12" r="1"/><circle cx="5" cy="19" r="1"/><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg></button>
+            <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button>
+            <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg></button>
+            <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg></button>
+            <button><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg></button>
+          </div>
+          <h1 class="email-title">Lorem Ipsum</h1>
+          <div class="email-image-slot">
+            <span>492 x 280</span>
+          </div>
+          <div class="email-text">
+            Omnimod quis quam, vendandi cor repudita ipsunt proratur sequid untium assitae velestio is est, corepudita quam vent laborei ciamust, quati aborio.
+          </div>
+          <a href="#" class="email-button">Cliquez-ici</a>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+
+<!-- ============= PANNEAU DE DÉTAIL ============= -->
+<div class="detail-panel" id="detailPanel">
+  <div class="detail-head">
+    <div class="detail-title" id="detailTitle">Détails de l'image</div>
+    <button class="detail-close" onclick="closeDetail()">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+    </button>
+  </div>
+  <div class="detail-body">
+    <div class="detail-preview" id="detailPreview"></div>
+    <div class="detail-field">
+      <span class="detail-label">Libellé</span>
+      <span class="detail-value" id="detailLabel">—</span>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Dimensions</span>
+      <span class="detail-value" id="detailDims">—</span>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Format</span>
+      <span class="detail-value" id="detailFormat">—</span>
+    </div>
+    <div class="detail-field" id="detailWeightRow" style="display: none;">
+      <span class="detail-label">Poids</span>
+      <span class="detail-value" id="detailWeight">—</span>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Uploadée le</span>
+      <span class="detail-value" id="detailDate">—</span>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Par</span>
+      <span class="detail-value" id="detailAuthor">—</span>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Collections</span>
+      <div class="detail-collections" id="detailColls"></div>
+    </div>
+    <div class="detail-field">
+      <span class="detail-label">Usage</span>
+      <span class="detail-value" id="detailUsage">—</span>
+    </div>
+  </div>
+  <div class="detail-actions">
+    <button class="detail-btn primary">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+      Éditer l'image
+    </button>
+    <button class="detail-btn" onclick="showCollectionModal(false)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      Gérer les collections
+    </button>
+    <button class="detail-btn">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 20h16M12 4v12M6 10l6 6 6-6"/></svg>
+      Renommer
+    </button>
+    <button class="detail-btn">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+      Télécharger
+    </button>
+    <button class="detail-btn danger" onclick="showDeleteModal(false)">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+      Supprimer
+    </button>
+  </div>
+</div>
+
+<!-- ============= MODALE COLLECTIONS ============= -->
+<div class="modal-backdrop" id="collectionModal">
+  <div class="modal">
+    <div class="modal-head">
+      <div class="modal-title">Gérer les collections</div>
+      <button class="detail-close" onclick="closeCollectionModal()">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p id="collectionModalDesc">Cochez les collections pour cette image :</p>
+      <ul class="collection-checklist">
+        <li><input type="checkbox" id="c1" checked><label for="c1">Pictos marque</label></li>
+        <li><input type="checkbox" id="c2"><label for="c2">Soldes Printemps 26</label></li>
+        <li><input type="checkbox" id="c3"><label for="c3">Bannières hero</label></li>
+      </ul>
+      <div class="collection-new-inline">
+        <input type="text" placeholder="Créer une nouvelle collection...">
+        <button class="modal-btn primary">Créer</button>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeCollectionModal()">Annuler</button>
+      <button class="modal-btn primary" onclick="closeCollectionModal()">Enregistrer</button>
+    </div>
+  </div>
+</div>
+
+<!-- ============= MODALE CONFIRMATION SUPPRESSION ============= -->
+<div class="modal-backdrop" id="deleteModal">
+  <div class="modal">
+    <div class="modal-head">
+      <div class="modal-title" style="color: var(--lp-danger);">Supprimer ?</div>
+    </div>
+    <div class="modal-body">
+      <p id="deleteWarning" style="font-weight: 500; color: var(--lp-danger);">⚠ Cette image est utilisée dans 2 emails.</p>
+      <p>Elle sera déplacée dans la corbeille et automatiquement supprimée après 30 jours. Vous pouvez la restaurer à tout moment d'ici là.</p>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeDeleteModal()">Annuler</button>
+      <button class="modal-btn danger" onclick="closeDeleteModal()">Déplacer dans la corbeille</button>
+    </div>
+  </div>
+</div>
+
+<!-- Astuce de démo -->
+<div class="demo-tip" id="demoTip">
+  <strong>Maquette interactive</strong> — Essayez : survoler une vignette, changer d'onglet, cliquer sur une collection, sélectionner plusieurs images, cliquer sur une image pour ouvrir les détails.
+  <br>
+  <button onclick="this.parentElement.style.display='none'">Compris</button>
+</div>
+
+<script>
+  // ========== DATA MOCK ==========
+  // Couleurs variées pour les thumbs, inspirées d'icônes/images marketing
+  const palette = [
+    ['#f7d794', '#e58e26'], ['#7ed6df', '#22a6b3'], ['#e77f67', '#cd6133'],
+    ['#778beb', '#4834d4'], ['#786fa6', '#574b90'], ['#f8a5c2', '#cc8e9e'],
+    ['#63cdda', '#3dc1d3'], ['#ea8685', '#b33939'], ['#f3a683', '#e15f41'],
+    ['#cf6a87', '#b53471'], ['#ffda79', '#ccae62'], ['#ea8685', '#c44569']
+  ];
+
+  const iconShapes = ['gift', 'heart', 'bag', 'tag', 'star', 'truck', 'shield', 'bell', 'diamond', 'flame', 'leaf', 'sun'];
+
+  function svgIcon(name, color) {
+    const icons = {
+      gift: '<rect x="4" y="10" width="24" height="18" rx="2"/><rect x="2" y="6" width="28" height="6"/><path d="M16 6v22M12 6c-2 0-4-2-4-4s2-2 4 0 4 4 4 4M20 6c2 0 4-2 4-4s-2-2-4 0-4 4-4 4"/>',
+      heart: '<path d="M16 28C8 22 3 18 3 12c0-4 3-7 7-7 2 0 4 1 6 3 2-2 4-3 6-3 4 0 7 3 7 7 0 6-5 10-13 16z"/>',
+      bag: '<path d="M6 10h20l-2 18H8L6 10z"/><path d="M11 10V6a5 5 0 0 1 10 0v4"/>',
+      tag: '<path d="M18 2l12 12-14 14L4 16V4h12z"/><circle cx="10" cy="10" r="2"/>',
+      star: '<path d="M16 3l4 9 10 1-7 7 2 10-9-5-9 5 2-10-7-7 10-1z"/>',
+      truck: '<rect x="2" y="10" width="16" height="12"/><path d="M18 14h8l4 5v3h-12z"/><circle cx="8" cy="24" r="3"/><circle cx="24" cy="24" r="3"/>',
+      shield: '<path d="M16 3l12 5v8c0 7-5 12-12 14C9 28 4 23 4 16V8z"/>',
+      bell: '<path d="M8 22V14a8 8 0 1 1 16 0v8l2 2H6z"/><path d="M13 26a3 3 0 0 0 6 0"/>',
+      diamond: '<path d="M8 4h16l6 8-14 16L2 12z"/>',
+      flame: '<path d="M16 2c4 6 10 10 10 16 0 5-4 10-10 10S6 23 6 18c0-4 3-6 5-10 2 4 4 6 5 6 0-6 0-10 0-12z"/>',
+      leaf: '<path d="M4 28c0-14 12-24 24-24 0 14-10 24-24 24z"/><path d="M4 28C10 20 18 14 28 4"/>',
+      sun: '<circle cx="16" cy="16" r="6"/><path d="M16 2v4M16 26v4M2 16h4M26 16h4M6 6l3 3M23 23l3 3M26 6l-3 3M9 23l-3 3"/>'
+    };
+    return `<svg viewBox="0 0 32 32" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" width="55%" height="55%">${icons[name] || icons.star}</svg>`;
+  }
+
+  function makeImage(i, format) {
+    const [bg, fg] = palette[i % palette.length];
+    const shape = iconShapes[i % iconShapes.length];
+    const labels = {
+      0: 'logo_clarins_red.png',
+      1: 'picto_livraison.svg',
+      2: 'picto_garantie.svg',
+      3: 'cover_soldes_hiver_26.jpg',
+      4: 'produit_serum_200ml.jpg',
+      5: 'banner_hero_printemps.jpg',
+      6: 'picto_retour_gratuit.png',
+      7: 'picto_paiement_securise.png',
+      8: 'visuel_rouge_levres.jpg',
+      9: 'animation_unboxing.gif',
+      10: 'picto_newsletter.png',
+      11: 'header_mothers_day.jpg'
+    };
+    return {
+      id: i,
+      label: labels[i % 12] || `image_${i + 1}.${format}`,
+      bg, fg, shape,
+      format: format || ['jpg', 'png', 'gif', 'png', 'jpg'][i % 5],
+      dims: ['1200 × 800 px', '600 × 600 px', '1920 × 1080 px', '400 × 400 px'][i % 4],
+      weight: '1.2 Mo',
+      date: '14 avril 2026',
+      author: ['Marie L.', 'Alex B.', 'Sophie R.', 'Thomas K.'][i % 4],
+      collections: [['Pictos marque'], ['Soldes Printemps 26'], ['Bannières hero'], [], ['Pictos marque', 'Soldes Printemps 26']][i % 5],
+      usage: i % 3 === 0 ? 'Utilisée dans 2 email(s)' : (i % 3 === 1 ? 'Utilisée dans 1 email' : 'Non utilisée')
+    };
+  }
+
+  let images = [];
+  for (let i = 0; i < 42; i++) images.push(makeImage(i));
+
+  let currentTab = 'template';
+  let selectedIds = new Set();
+  let currentCollection = 'all';
+
+  // ========== RENDU ==========
+  function renderGrid() {
+    const grid = document.getElementById('grid');
+    const collectionsBar = document.getElementById('collectionsBar');
+    const metaCount = document.getElementById('metaCount');
+
+    if (currentTab === 'email') {
+      collectionsBar.classList.remove('visible');
+      const emailImages = images.slice(0, 4);
+      if (emailImages.length === 0) {
+        grid.innerHTML = emptyStateHTML('email');
+        metaCount.textContent = '0 image';
+        return;
+      }
+      renderImages(emailImages);
+      metaCount.textContent = `${emailImages.length} images`;
+    } else {
+      collectionsBar.classList.add('visible');
+      let filtered = images;
+      if (currentCollection === 'unclassified') {
+        filtered = images.filter(im => im.collections.length === 0);
+      } else if (currentCollection !== 'all') {
+        const collMap = { pictos: 'Pictos marque', soldes: 'Soldes Printemps 26', hero: 'Bannières hero' };
+        filtered = images.filter(im => im.collections.includes(collMap[currentCollection]));
+      }
+      if (filtered.length === 0) {
+        grid.innerHTML = emptyStateHTML('collection');
+        metaCount.textContent = '0 image';
+        return;
+      }
+      renderImages(filtered);
+      metaCount.textContent = `${filtered.length} images`;
+    }
+  }
+
+  function emptyStateHTML(type) {
+    if (type === 'email') {
+      return `<div style="grid-column: 1/-1;" class="empty-state">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M21 15l-5-5L5 21"/></svg>
+        <div class="empty-state-title">Aucune image pour cet email</div>
+        <div class="empty-state-msg">Déposez vos premières images ou récupérez-les depuis la galerie commune.</div>
+      </div>`;
+    }
+    return `<div style="grid-column: 1/-1;" class="empty-state">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+      <div class="empty-state-title">Collection vide</div>
+      <div class="empty-state-msg">Ajoutez des images à cette collection via l'action "Gérer les collections".</div>
+    </div>`;
+  }
+
+  function renderImages(list) {
+    const grid = document.getElementById('grid');
+    grid.innerHTML = list.map(img => {
+      const isSelected = selectedIds.has(img.id);
+      const isGif = img.format === 'gif';
+      return `
+        <div class="thumb ${isSelected ? 'selected' : ''}" data-id="${img.id}" onclick="onThumbClick(event, ${img.id})">
+          <div class="thumb-check ${isSelected ? 'checked' : ''}" onclick="event.stopPropagation(); toggleSelect(${img.id})">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+          </div>
+          ${isGif ? '<div class="thumb-badge gif">GIF</div>' : ''}
+          <div class="thumb-img" style="background: linear-gradient(135deg, ${img.bg}22, ${img.bg}55);">
+            ${svgIcon(img.shape, img.fg)}
+          </div>
+          <div class="thumb-label" title="${img.label}">${img.label}</div>
+          <div class="thumb-overlay">
+            <div class="thumb-actions">
+              <button class="thumb-action" title="Éditer" onclick="event.stopPropagation(); alert('Relance de l\\'éditeur Konva sur cette image')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+              </button>
+              <button class="thumb-action" title="Collections" onclick="event.stopPropagation(); showCollectionModal(false)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </button>
+              <button class="thumb-action danger" title="Supprimer" onclick="event.stopPropagation(); showDeleteModal(false)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+  }
+
+  // ========== INTERACTIONS ==========
+  function onThumbClick(e, id) {
+    // Si shift, on sélectionne
+    if (e.shiftKey || selectedIds.size > 0) {
+      toggleSelect(id);
+      return;
+    }
+    // Sinon on ouvre les détails
+    openDetail(id);
+  }
+
+  function toggleSelect(id) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+    renderGrid();
+    updateBulkBar();
+  }
+
+  function clearSelection() {
+    selectedIds.clear();
+    renderGrid();
+    updateBulkBar();
+  }
+
+  function updateBulkBar() {
+    const bar = document.getElementById('bulkBar');
+    if (selectedIds.size > 0) {
+      bar.classList.add('visible');
+      document.getElementById('bulkCount').textContent = selectedIds.size;
+    } else {
+      bar.classList.remove('visible');
+    }
+  }
+
+  function openDetail(id) {
+    const img = images[id];
+    document.getElementById('detailLabel').textContent = img.label;
+    document.getElementById('detailDims').textContent = img.dims;
+    document.getElementById('detailFormat').textContent = img.format.toUpperCase();
+    document.getElementById('detailDate').textContent = img.date;
+    document.getElementById('detailAuthor').textContent = img.author;
+    // Poids uniquement si GIF
+    const weightRow = document.getElementById('detailWeightRow');
+    if (img.format === 'gif') {
+      weightRow.style.display = 'flex';
+      document.getElementById('detailWeight').textContent = img.weight;
+    } else {
+      weightRow.style.display = 'none';
+    }
+    // Collections
+    const colls = document.getElementById('detailColls');
+    if (img.collections.length === 0) {
+      colls.innerHTML = '<span style="color: var(--lp-text-faint); font-style: italic; font-size: 11px;">Non classée</span>';
+    } else {
+      colls.innerHTML = img.collections.map(c => `<span class="detail-coll">${c}</span>`).join('');
+    }
+    // Usage
+    const usage = document.getElementById('detailUsage');
+    usage.textContent = img.usage;
+    usage.className = 'detail-value ' + (img.usage.includes('Non') ? 'unused' : 'usage');
+    // Preview
+    document.getElementById('detailPreview').innerHTML = `
+      <div style="width: 80%; aspect-ratio: 1; display: flex; align-items: center; justify-content: center; background: linear-gradient(135deg, ${img.bg}22, ${img.bg}55); border-radius: 6px;">
+        ${svgIcon(img.shape, img.fg).replace('width="55%"', 'width="60%"').replace('height="55%"', 'height="60%"')}
+      </div>
+    `;
+    document.getElementById('detailPanel').classList.add('visible');
+  }
+
+  function closeDetail() {
+    document.getElementById('detailPanel').classList.remove('visible');
+  }
+
+  function showCollectionModal(bulk) {
+    document.getElementById('collectionModalDesc').textContent = bulk
+      ? `Ajouter les ${selectedIds.size} images sélectionnées à une collection :`
+      : 'Cochez les collections pour cette image :';
+    document.getElementById('collectionModal').classList.add('visible');
+  }
+  function closeCollectionModal() {
+    document.getElementById('collectionModal').classList.remove('visible');
+  }
+  function showNewCollectionModal() {
+    showCollectionModal(false);
+  }
+
+  function showDeleteModal(bulk) {
+    const warning = document.getElementById('deleteWarning');
+    if (bulk) {
+      warning.textContent = `⚠ ${selectedIds.size} image(s) sélectionnée(s). Certaines sont utilisées dans des emails.`;
+    } else {
+      warning.textContent = '⚠ Cette image est utilisée dans 2 emails.';
+    }
+    document.getElementById('deleteModal').classList.add('visible');
+  }
+  function closeDeleteModal() {
+    document.getElementById('deleteModal').classList.remove('visible');
+  }
+
+  // ========== BINDINGS ==========
+  document.querySelectorAll('.tab').forEach(t => {
+    t.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach(x => x.classList.remove('active'));
+      t.classList.add('active');
+      currentTab = t.dataset.tab;
+      selectedIds.clear();
+      updateBulkBar();
+      renderGrid();
+    });
+  });
+
+  document.querySelectorAll('.collection-pill').forEach(p => {
+    p.addEventListener('click', () => {
+      document.querySelectorAll('.collection-pill').forEach(x => x.classList.remove('active'));
+      p.classList.add('active');
+      currentCollection = p.dataset.collection;
+      renderGrid();
+    });
+  });
+
+  document.querySelectorAll('.filter-chip').forEach(f => {
+    f.addEventListener('click', () => {
+      document.querySelectorAll('.filter-chip').forEach(x => x.classList.remove('active'));
+      f.classList.add('active');
+    });
+  });
+
+  document.getElementById('selectAllBtn').addEventListener('click', () => {
+    const visibleImages = currentTab === 'email' ? images.slice(0, 4) : images;
+    if (selectedIds.size === visibleImages.length) {
+      selectedIds.clear();
+    } else {
+      visibleImages.forEach(im => selectedIds.add(im.id));
+    }
+    renderGrid();
+    updateBulkBar();
+  });
+
+  // Init
+  renderGrid();
+</script>
+</body>
+</html>

--- a/docs/gallery-redesign/mockup-v2.html
+++ b/docs/gallery-redesign/mockup-v2.html
@@ -1,0 +1,1739 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LePatron — Galerie v2 (split layout)</title>
+<style>
+  /* =========================================================
+     DESIGN TOKENS — alignés sur la refonte de Jonathan
+     ========================================================= */
+  :root {
+    --lp-navy: #0d3b4f;
+    --lp-cyan: #1bb5d6;
+    --lp-cyan-dark: #0f94b0;
+    --lp-cyan-soft: #e6f7fb;
+
+    /* Fonds épurés (aligné avec la nouvelle interface Shine) */
+    --lp-bg: #f4f5f7;
+    --lp-panel: #ffffff;
+    --lp-panel-alt: #f9fafb;
+    --lp-border: #e4e7eb;
+    --lp-border-strong: #cfd4da;
+
+    --lp-text: #1f2937;
+    --lp-text-muted: #6b7280;
+    --lp-text-faint: #9ca3af;
+
+    --lp-danger: #d84a3a;
+    --lp-danger-soft: #fdeceb;
+    --lp-success: #059669;
+    --lp-warning: #e8a93a;
+
+    --lp-radius-sm: 4px;
+    --lp-radius: 6px;
+    --lp-radius-lg: 10px;
+
+    --lp-shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04);
+    --lp-shadow: 0 2px 8px rgba(15, 23, 42, 0.06);
+    --lp-shadow-lg: 0 10px 30px rgba(15, 23, 42, 0.12);
+
+    /* Largeurs panneaux (valeurs à affiner avec Jonathan) */
+    --panel-left: 280px;
+    --panel-right: 340px;
+    --panel-padding: 14px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    color: var(--lp-text);
+    background: var(--lp-bg);
+    height: 100vh;
+    overflow: hidden;
+    font-size: 13px;
+    line-height: 1.45;
+  }
+
+  /* =========================================================
+     LAYOUT — split gauche/canvas/droite
+     ========================================================= */
+  .app {
+    display: grid;
+    grid-template-rows: 52px 1fr;
+    height: 100vh;
+  }
+
+  /* Header clair (style Jonathan) */
+  .header {
+    background: var(--lp-navy);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    padding: 0 14px;
+    gap: 14px;
+  }
+  .header-left { display: flex; align-items: center; gap: 10px; }
+  .header-title {
+    flex: 1;
+    text-align: center;
+    font-size: 13px;
+    font-weight: 500;
+    opacity: 0.95;
+  }
+  .header-right { display: flex; align-items: center; gap: 4px; }
+  .header-btn {
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: transparent;
+    color: #fff;
+    opacity: 0.75;
+    cursor: pointer;
+    border-radius: var(--lp-radius-sm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.15s;
+  }
+  .header-btn:hover { opacity: 1; background: rgba(255,255,255,0.08); }
+  .header-btn.active { background: var(--lp-cyan); opacity: 1; }
+  .header-btn svg { width: 16px; height: 16px; }
+  .header-save {
+    background: #fff;
+    color: var(--lp-navy);
+    border: none;
+    padding: 6px 12px;
+    border-radius: var(--lp-radius);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: inherit;
+  }
+  .header-save:hover { background: var(--lp-panel-alt); }
+  .header-save svg { width: 14px; height: 14px; }
+
+  .main {
+    display: grid;
+    grid-template-columns: var(--panel-left) 1fr var(--panel-right);
+    overflow: hidden;
+  }
+
+  /* =========================================================
+     PANNEAU GAUCHE — Navigation + Galerie
+     ========================================================= */
+  .left-panel {
+    background: var(--lp-panel);
+    border-right: 1px solid var(--lp-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  /* Onglets principaux Blocs / Enregistrés / Images */
+  .main-tabs {
+    display: flex;
+    padding: 10px 10px 0;
+    border-bottom: 1px solid var(--lp-border);
+    gap: 2px;
+  }
+  .main-tab {
+    flex: 1;
+    padding: 10px 6px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--lp-text-muted);
+    border-bottom: 2px solid transparent;
+    font-family: inherit;
+    transition: all 0.15s;
+  }
+  .main-tab:hover { color: var(--lp-text); }
+  .main-tab.active {
+    color: var(--lp-navy);
+    border-bottom-color: var(--lp-navy);
+    font-weight: 600;
+  }
+
+  /* Sous-onglets galerie */
+  .sub-tabs {
+    display: flex;
+    padding: 8px 10px 0;
+    gap: 4px;
+  }
+  .sub-tab {
+    flex: 1;
+    padding: 6px 8px;
+    border: 1px solid var(--lp-border);
+    background: var(--lp-panel);
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--lp-text-muted);
+    border-radius: var(--lp-radius-sm);
+    font-family: inherit;
+    transition: all 0.15s;
+    text-align: center;
+    line-height: 1.2;
+  }
+  .sub-tab:hover { border-color: var(--lp-border-strong); color: var(--lp-text); }
+  .sub-tab.active {
+    background: var(--lp-cyan-soft);
+    border-color: var(--lp-cyan);
+    color: var(--lp-cyan-dark);
+  }
+
+  /* Recherche */
+  .search {
+    position: relative;
+    padding: 10px var(--panel-padding) 8px;
+  }
+  .search input {
+    width: 100%;
+    padding: 7px 10px 7px 30px;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    font-size: 12px;
+    background: var(--lp-panel-alt);
+    font-family: inherit;
+    color: var(--lp-text);
+    transition: all 0.15s;
+  }
+  .search input:focus {
+    outline: none;
+    border-color: var(--lp-cyan);
+    background: #fff;
+    box-shadow: 0 0 0 3px var(--lp-cyan-soft);
+  }
+  .search svg {
+    position: absolute;
+    left: calc(var(--panel-padding) + 9px);
+    top: 50%;
+    transform: translateY(-50%);
+    width: 14px;
+    height: 14px;
+    color: var(--lp-text-faint);
+    pointer-events: none;
+  }
+
+  /* Filtres compacts */
+  .filters {
+    padding: 0 var(--panel-padding) 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+  .filter-chip {
+    padding: 3px 8px;
+    border: 1px solid var(--lp-border);
+    border-radius: 12px;
+    background: var(--lp-panel);
+    color: var(--lp-text-muted);
+    font-size: 11px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: all 0.15s;
+  }
+  .filter-chip:hover { border-color: var(--lp-border-strong); color: var(--lp-text); }
+  .filter-chip.active {
+    background: var(--lp-navy);
+    border-color: var(--lp-navy);
+    color: #fff;
+  }
+
+  /* Upload compact */
+  .upload-zone {
+    margin: 0 var(--panel-padding) 8px;
+    padding: 7px 10px;
+    border: 1.5px dashed var(--lp-border-strong);
+    border-radius: var(--lp-radius);
+    text-align: center;
+    cursor: pointer;
+    font-size: 11px;
+    color: var(--lp-text-muted);
+    background: var(--lp-panel-alt);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    transition: all 0.15s;
+  }
+  .upload-zone:hover {
+    border-color: var(--lp-cyan);
+    color: var(--lp-cyan-dark);
+    background: var(--lp-cyan-soft);
+  }
+  .upload-zone svg { width: 12px; height: 12px; }
+
+  /* Compteur */
+  .gallery-meta {
+    padding: 2px var(--panel-padding) 6px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 11px;
+    color: var(--lp-text-muted);
+  }
+  .meta-link {
+    background: none;
+    border: none;
+    color: var(--lp-cyan-dark);
+    cursor: pointer;
+    font-size: 11px;
+    font-family: inherit;
+    padding: 0;
+  }
+  .meta-link:hover { text-decoration: underline; }
+
+  /* Bulk bar compact */
+  .bulk-bar {
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+    padding: 7px var(--panel-padding);
+    background: var(--lp-navy);
+    color: #fff;
+    font-size: 11px;
+  }
+  .bulk-bar.visible { display: flex; }
+  .bulk-bar .small-btn {
+    background: rgba(255,255,255,0.12);
+    border: none;
+    color: #fff;
+    padding: 3px 8px;
+    border-radius: var(--lp-radius-sm);
+    cursor: pointer;
+    font-size: 11px;
+    font-family: inherit;
+  }
+  .bulk-bar .small-btn:hover { background: rgba(255,255,255,0.2); }
+
+  /* Grille 2 colonnes */
+  .grid-wrap {
+    flex: 1;
+    overflow-y: auto;
+    padding: 2px var(--panel-padding) 16px;
+  }
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+
+  .thumb {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    overflow: hidden;
+    cursor: pointer;
+    background: var(--lp-panel-alt);
+    transition: all 0.12s;
+  }
+  .thumb:hover {
+    border-color: var(--lp-cyan);
+    box-shadow: var(--lp-shadow);
+    transform: translateY(-1px);
+  }
+  .thumb.selected {
+    border-color: var(--lp-cyan);
+    border-width: 2px;
+    box-shadow: 0 0 0 2px var(--lp-cyan-soft);
+  }
+  .thumb.highlighted {
+    border-color: var(--lp-cyan);
+    border-width: 2px;
+    box-shadow: 0 0 0 2px var(--lp-cyan-soft), var(--lp-shadow);
+  }
+
+  .thumb-img {
+    width: 100%;
+    height: 74%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    /* Fond damier pour visualiser la transparence */
+    background-color: #fff;
+    background-image:
+      linear-gradient(45deg, #e8eaed 25%, transparent 25%),
+      linear-gradient(-45deg, #e8eaed 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #e8eaed 75%),
+      linear-gradient(-45deg, transparent 75%, #e8eaed 75%);
+    background-size: 12px 12px;
+    background-position: 0 0, 0 6px, 6px -6px, -6px 0;
+  }
+  .thumb-img.solid {
+    /* Images à fond coloré — pas de damier */
+    background-image: none;
+  }
+  .thumb-img-inner {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .thumb-label {
+    height: 26%;
+    padding: 4px 6px;
+    font-size: 10.5px;
+    color: var(--lp-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
+    background: #fff;
+    border-top: 1px solid var(--lp-border);
+  }
+
+  .thumb-badge {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    background: rgba(13, 59, 79, 0.85);
+    color: #fff;
+    font-size: 9px;
+    font-weight: 600;
+    padding: 2px 5px;
+    border-radius: 3px;
+    letter-spacing: 0.3px;
+    z-index: 2;
+  }
+  .thumb-badge.gif { background: var(--lp-warning); color: var(--lp-navy); }
+
+  .thumb-check {
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: 18px;
+    height: 18px;
+    border-radius: 3px;
+    background: rgba(255,255,255,0.95);
+    border: 1px solid var(--lp-border-strong);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 0.12s;
+    cursor: pointer;
+    z-index: 3;
+  }
+  .thumb:hover .thumb-check,
+  .thumb.selected .thumb-check,
+  .selection-mode .thumb-check { opacity: 1; }
+  .thumb-check.checked {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+  }
+  .thumb-check svg { width: 12px; height: 12px; color: #fff; display: none; }
+  .thumb-check.checked svg { display: block; }
+
+  .thumb-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 0%, transparent 55%, rgba(13,59,79,0.75) 100%);
+    opacity: 0;
+    transition: opacity 0.12s;
+    pointer-events: none;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 4px;
+    z-index: 2;
+  }
+  .thumb:hover .thumb-overlay { opacity: 1; pointer-events: auto; }
+  .thumb-actions {
+    display: flex;
+    gap: 2px;
+    background: rgba(255,255,255,0.96);
+    border-radius: var(--lp-radius-sm);
+    padding: 2px;
+    box-shadow: var(--lp-shadow);
+  }
+  .thumb-action {
+    width: 22px;
+    height: 22px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--lp-text);
+  }
+  .thumb-action:hover { background: var(--lp-cyan-soft); color: var(--lp-cyan-dark); }
+  .thumb-action.danger:hover { background: var(--lp-danger-soft); color: var(--lp-danger); }
+  .thumb-action svg { width: 12px; height: 12px; }
+
+  /* État vide */
+  .empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--lp-text-muted);
+  }
+  .empty-state svg { width: 40px; height: 40px; color: var(--lp-text-faint); margin-bottom: 10px; }
+  .empty-state-title { font-size: 13px; font-weight: 500; color: var(--lp-text); margin-bottom: 4px; }
+  .empty-state-msg { font-size: 11px; line-height: 1.5; }
+
+  /* =========================================================
+     CANVAS EMAIL
+     ========================================================= */
+  .email-canvas {
+    background: var(--lp-bg);
+    overflow-y: auto;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+  }
+  .email-preview {
+    width: 100%;
+    max-width: 540px;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: var(--lp-shadow);
+  }
+  .email-preheader { text-align: center; padding: 8px; font-size: 11px; color: var(--lp-text-muted); }
+  .email-header-brand { background: #ffd200; padding: 20px; text-align: right; }
+  .email-header-brand .logo {
+    display: inline-block;
+    background: #1a3a7a;
+    color: #fff;
+    padding: 8px 14px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    font-size: 12px;
+  }
+  .email-body {
+    padding: 20px;
+    border: 2px solid #ffd200;
+    margin: 10px;
+    border-radius: 4px;
+    position: relative;
+  }
+  .email-title { text-align: center; color: #1a3a7a; font-size: 22px; font-weight: 700; margin: 6px 0 16px; }
+  .email-image-slot {
+    background: repeating-linear-gradient(-45deg, #a8a8a8, #a8a8a8 10px, #9c9c9c 10px, #9c9c9c 20px);
+    height: 220px;
+    position: relative;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  .email-image-slot::before {
+    content: "Déposer une image ici";
+    position: absolute;
+    top: 10px;
+    color: #000;
+    font-weight: 700;
+    font-size: 13px;
+  }
+  .email-image-slot span { color: #e0e0e0; font-size: 17px; }
+  .email-text { padding: 14px 0; font-size: 12px; line-height: 1.6; color: #333; }
+  .email-button {
+    display: block;
+    width: fit-content;
+    margin: 8px auto;
+    background: #ffd200;
+    color: #1a3a7a;
+    padding: 12px 26px;
+    font-weight: 700;
+    text-decoration: none;
+    border-radius: 3px;
+    font-size: 13px;
+  }
+
+  /* =========================================================
+     PANNEAU DROIT — Contextuel (3 modes)
+     ========================================================= */
+  .right-panel {
+    background: var(--lp-panel);
+    border-left: 1px solid var(--lp-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .right-head {
+    padding: 14px 16px 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--lp-border);
+  }
+  .right-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--lp-text);
+    padding-bottom: 10px;
+  }
+  .right-mode-badge {
+    font-size: 10px;
+    text-transform: uppercase;
+    color: var(--lp-text-muted);
+    letter-spacing: 0.5px;
+    font-weight: 500;
+  }
+
+  .right-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 14px 16px;
+  }
+
+  /* MODE COLLECTIONS (défaut) */
+  .mode-collections { display: block; }
+  .mode-collections.hidden { display: none; }
+
+  .collection-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 12px;
+  }
+  .section-label {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--lp-text-muted);
+  }
+  .btn-text {
+    background: transparent;
+    border: none;
+    color: var(--lp-cyan-dark);
+    cursor: pointer;
+    font-size: 12px;
+    font-family: inherit;
+    padding: 4px 6px;
+    border-radius: var(--lp-radius-sm);
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .btn-text:hover { background: var(--lp-cyan-soft); }
+  .btn-text svg { width: 12px; height: 12px; }
+
+  .collection-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 9px 10px;
+    border-radius: var(--lp-radius);
+    cursor: pointer;
+    margin-bottom: 2px;
+    transition: background 0.12s;
+    border: 1px solid transparent;
+  }
+  .collection-item:hover { background: var(--lp-panel-alt); }
+  .collection-item.active {
+    background: var(--lp-cyan-soft);
+    border-color: var(--lp-cyan);
+  }
+  .collection-item.active .collection-name { color: var(--lp-cyan-dark); font-weight: 600; }
+
+  .collection-left {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    min-width: 0;
+    flex: 1;
+  }
+  .collection-icon {
+    width: 28px;
+    height: 28px;
+    border-radius: var(--lp-radius-sm);
+    background: var(--lp-panel-alt);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--lp-text-muted);
+    flex-shrink: 0;
+  }
+  .collection-item.active .collection-icon {
+    background: var(--lp-cyan);
+    color: #fff;
+  }
+  .collection-icon svg { width: 14px; height: 14px; }
+
+  .collection-name {
+    font-size: 13px;
+    color: var(--lp-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .collection-count {
+    font-size: 11px;
+    color: var(--lp-text-muted);
+    font-weight: 500;
+    margin-left: 6px;
+  }
+  .collection-menu {
+    width: 22px;
+    height: 22px;
+    border-radius: 3px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--lp-text-muted);
+    display: none;
+    align-items: center;
+    justify-content: center;
+  }
+  .collection-item:hover .collection-menu { display: flex; }
+  .collection-menu:hover { background: rgba(0,0,0,0.05); color: var(--lp-text); }
+  .collection-menu svg { width: 14px; height: 14px; }
+
+  .section-separator {
+    height: 1px;
+    background: var(--lp-border);
+    margin: 16px 0 12px;
+  }
+
+  /* Sous-section Tri/Affichage (dans le mode collections) */
+  .advanced-filters {
+    margin-top: 8px;
+  }
+  .filter-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    font-size: 12px;
+  }
+  .filter-row label { color: var(--lp-text-muted); }
+  .filter-row select {
+    padding: 4px 8px;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius-sm);
+    background: #fff;
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--lp-text);
+    cursor: pointer;
+  }
+
+  /* MODE DÉTAILS (image cliquée) */
+  .mode-details { display: none; }
+  .mode-details.visible { display: block; }
+
+  .detail-preview {
+    aspect-ratio: 1;
+    background-color: #fff;
+    background-image:
+      linear-gradient(45deg, #e8eaed 25%, transparent 25%),
+      linear-gradient(-45deg, #e8eaed 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #e8eaed 75%),
+      linear-gradient(-45deg, transparent 75%, #e8eaed 75%);
+    background-size: 16px 16px;
+    background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    margin-bottom: 14px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    position: relative;
+  }
+  .detail-preview .inner {
+    width: 72%;
+    height: 72%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .detail-preview.solid {
+    background-image: none;
+  }
+  .detail-section {
+    margin-bottom: 14px;
+  }
+  .detail-filename {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--lp-text);
+    margin-bottom: 2px;
+    word-break: break-all;
+  }
+  .detail-subline {
+    font-size: 11px;
+    color: var(--lp-text-muted);
+  }
+  .detail-fields {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    background: var(--lp-panel-alt);
+    border-radius: var(--lp-radius);
+    padding: 2px 12px;
+  }
+  .detail-field {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--lp-border);
+    font-size: 12px;
+  }
+  .detail-field:last-child { border-bottom: none; }
+  .detail-label { color: var(--lp-text-muted); }
+  .detail-value { color: var(--lp-text); font-weight: 500; text-align: right; }
+
+  .usage-pill {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+  .usage-pill.used {
+    background: rgba(5, 150, 105, 0.1);
+    color: var(--lp-success);
+  }
+  .usage-pill.unused {
+    background: var(--lp-panel-alt);
+    color: var(--lp-text-faint);
+    font-style: italic;
+  }
+
+  .detail-collections-wrap {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 8px;
+  }
+  .detail-coll-pill {
+    background: var(--lp-cyan-soft);
+    color: var(--lp-cyan-dark);
+    padding: 3px 9px;
+    border-radius: 11px;
+    font-size: 11px;
+    font-weight: 500;
+  }
+
+  .detail-actions {
+    padding: 14px 16px;
+    border-top: 1px solid var(--lp-border);
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+  }
+  .action-btn {
+    padding: 8px 10px;
+    border: 1px solid var(--lp-border);
+    background: #fff;
+    border-radius: var(--lp-radius);
+    cursor: pointer;
+    font-size: 12px;
+    font-family: inherit;
+    color: var(--lp-text);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: all 0.12s;
+  }
+  .action-btn:hover {
+    border-color: var(--lp-cyan);
+    color: var(--lp-cyan-dark);
+    background: var(--lp-cyan-soft);
+  }
+  .action-btn.primary {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+    color: #fff;
+    grid-column: span 2;
+  }
+  .action-btn.primary:hover {
+    background: var(--lp-cyan-dark);
+    color: #fff;
+  }
+  .action-btn.danger {
+    color: var(--lp-danger);
+  }
+  .action-btn.danger:hover {
+    background: var(--lp-danger-soft);
+    border-color: var(--lp-danger);
+    color: var(--lp-danger);
+  }
+  .action-btn svg { width: 13px; height: 13px; }
+
+  /* MODE BULK (sélection multiple) */
+  .mode-bulk { display: none; }
+  .mode-bulk.visible { display: block; }
+
+  .bulk-hero {
+    background: var(--lp-navy);
+    color: #fff;
+    border-radius: var(--lp-radius);
+    padding: 16px;
+    text-align: center;
+    margin-bottom: 16px;
+  }
+  .bulk-hero-count {
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 4px;
+  }
+  .bulk-hero-label {
+    font-size: 12px;
+    opacity: 0.85;
+  }
+
+  .bulk-actions-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .bulk-action-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 11px 12px;
+    border: 1px solid var(--lp-border);
+    background: #fff;
+    border-radius: var(--lp-radius);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+    color: var(--lp-text);
+    transition: all 0.12s;
+    text-align: left;
+  }
+  .bulk-action-item:hover {
+    border-color: var(--lp-cyan);
+    background: var(--lp-cyan-soft);
+  }
+  .bulk-action-item.danger:hover {
+    border-color: var(--lp-danger);
+    background: var(--lp-danger-soft);
+    color: var(--lp-danger);
+  }
+  .bulk-action-item svg { width: 15px; height: 15px; color: var(--lp-text-muted); }
+  .bulk-action-item:hover svg { color: inherit; }
+  .bulk-action-item.danger svg { color: var(--lp-danger); }
+
+  /* =========================================================
+     MODALES (réutilisées de la v1)
+     ========================================================= */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.4);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+  }
+  .modal-backdrop.visible { display: flex; }
+  .modal {
+    background: #fff;
+    border-radius: var(--lp-radius-lg);
+    box-shadow: var(--lp-shadow-lg);
+    width: 420px;
+    max-width: 90vw;
+    overflow: hidden;
+  }
+  .modal-head {
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--lp-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .modal-title { font-size: 14px; font-weight: 600; color: var(--lp-text); }
+  .modal-close {
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: var(--lp-text-muted);
+    width: 26px; height: 26px;
+    border-radius: var(--lp-radius-sm);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .modal-close:hover { background: var(--lp-panel-alt); }
+  .modal-body { padding: 16px 18px; font-size: 13px; color: var(--lp-text); }
+  .modal-body p { margin: 0 0 10px; }
+  .modal-footer {
+    padding: 10px 18px;
+    display: flex;
+    justify-content: flex-end;
+    gap: 6px;
+    border-top: 1px solid var(--lp-border);
+    background: var(--lp-panel-alt);
+  }
+  .modal-btn {
+    padding: 7px 14px;
+    border-radius: var(--lp-radius);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    border: 1px solid var(--lp-border-strong);
+    background: #fff;
+    color: var(--lp-text);
+  }
+  .modal-btn:hover { background: var(--lp-panel-alt); }
+  .modal-btn.primary {
+    background: var(--lp-cyan);
+    border-color: var(--lp-cyan);
+    color: #fff;
+  }
+  .modal-btn.primary:hover { background: var(--lp-cyan-dark); }
+  .modal-btn.danger {
+    background: var(--lp-danger);
+    border-color: var(--lp-danger);
+    color: #fff;
+  }
+  .modal-btn.danger:hover { background: #b83a2d; }
+
+  .collection-checklist { list-style: none; padding: 0; margin: 0; }
+  .collection-checklist li {
+    padding: 8px 12px;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .collection-checklist li:hover { background: var(--lp-panel-alt); }
+  .collection-new-inline {
+    margin-top: 10px;
+    display: flex;
+    gap: 6px;
+  }
+  .collection-new-inline input {
+    flex: 1;
+    padding: 6px 10px;
+    border: 1px solid var(--lp-border);
+    border-radius: var(--lp-radius);
+    font-size: 12px;
+    font-family: inherit;
+  }
+  .collection-new-inline input:focus { outline: none; border-color: var(--lp-cyan); }
+
+  /* Scrollbars */
+  .grid-wrap::-webkit-scrollbar,
+  .right-body::-webkit-scrollbar,
+  .email-canvas::-webkit-scrollbar { width: 8px; }
+  .grid-wrap::-webkit-scrollbar-thumb,
+  .right-body::-webkit-scrollbar-thumb,
+  .email-canvas::-webkit-scrollbar-thumb { background: var(--lp-border-strong); border-radius: 4px; }
+
+  /* Demo tip */
+  .demo-tip {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--lp-navy);
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: var(--lp-radius);
+    font-size: 11px;
+    box-shadow: var(--lp-shadow-lg);
+    z-index: 100;
+    max-width: 500px;
+    line-height: 1.5;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .demo-tip strong { color: var(--lp-cyan); }
+  .demo-tip button {
+    background: transparent;
+    border: 1px solid rgba(255,255,255,0.3);
+    color: #fff;
+    padding: 3px 9px;
+    border-radius: 3px;
+    font-size: 10px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+</style>
+</head>
+<body>
+
+<div class="app">
+  <!-- ============= HEADER ============= -->
+  <header class="header">
+    <div class="header-left">
+      <button class="header-btn" title="Retour">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+      </button>
+    </div>
+    <div class="header-title">test shine 2</div>
+    <div class="header-right">
+      <button class="header-btn" title="Vue desktop">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
+      </button>
+      <button class="header-btn" title="Vue mobile">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="5" y="2" width="14" height="20" rx="2"/></svg>
+      </button>
+      <button class="header-btn" title="Annuler"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg></button>
+      <button class="header-btn" title="Rétablir"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg></button>
+      <button class="header-save">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+        Sauvegarder
+      </button>
+    </div>
+  </header>
+
+  <div class="main">
+    <!-- ============= PANNEAU GAUCHE ============= -->
+    <aside class="left-panel">
+      <!-- Onglets principaux (style Jonathan) -->
+      <nav class="main-tabs">
+        <button class="main-tab">Blocs</button>
+        <button class="main-tab">Enregistrés</button>
+        <button class="main-tab active">Images</button>
+      </nav>
+
+      <!-- Sous-onglets de la galerie -->
+      <div class="sub-tabs">
+        <button class="sub-tab" data-tab="email">Spécifique à l'email</button>
+        <button class="sub-tab active" data-tab="template">Commun au template</button>
+      </div>
+
+      <div class="search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="M21 21l-4.35-4.35"/></svg>
+        <input type="text" placeholder="Rechercher...">
+      </div>
+
+      <div class="filters">
+        <button class="filter-chip active" data-filter="all">Tous</button>
+        <button class="filter-chip" data-filter="jpg">JPG</button>
+        <button class="filter-chip" data-filter="png">PNG</button>
+        <button class="filter-chip" data-filter="gif">GIF</button>
+      </div>
+
+      <div class="upload-zone">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
+        Glisser ou cliquer pour uploader
+      </div>
+
+      <div class="gallery-meta">
+        <span id="metaCount">42 images</span>
+        <button class="meta-link" id="selectAllBtn">Tout sélectionner</button>
+      </div>
+
+      <div class="bulk-bar" id="bulkBar">
+        <span><span id="bulkCountLeft">0</span> sélectionnée(s)</span>
+        <button class="small-btn" onclick="clearSelection()">Annuler</button>
+      </div>
+
+      <div class="grid-wrap">
+        <div class="grid" id="grid"></div>
+      </div>
+    </aside>
+
+    <!-- ============= CANVAS EMAIL ============= -->
+    <section class="email-canvas">
+      <div class="email-preview">
+        <div class="email-preheader"><a href="#">Version web</a> | <a href="#">Se désinscrire</a></div>
+        <div class="email-header-brand">
+          <span class="logo">LA POSTE</span>
+        </div>
+        <div class="email-body">
+          <h1 class="email-title">Lorem Ipsum</h1>
+          <div class="email-image-slot">
+            <span>492 × 280</span>
+          </div>
+          <div class="email-text">
+            Omnimod quis quam, vendandi cor repudita ipsunt proratur sequid untium assitae velestio is est, corepudita quam vent laborei ciamust.
+          </div>
+          <a href="#" class="email-button">Cliquez-ici</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============= PANNEAU DROIT ============= -->
+    <aside class="right-panel">
+      <div class="right-head">
+        <div class="right-title" id="rightTitle">Collections</div>
+        <div class="right-mode-badge" id="rightModeBadge">Navigation</div>
+      </div>
+
+      <div class="right-body">
+        <!-- MODE COLLECTIONS -->
+        <div class="mode-collections" id="modeCollections">
+          <div class="collection-head">
+            <span class="section-label">Vues</span>
+          </div>
+          <div class="collection-item active" data-collection="all">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+              </div>
+              <span class="collection-name">Toutes les images</span>
+            </div>
+            <span class="collection-count">42</span>
+          </div>
+          <div class="collection-item" data-collection="unclassified">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+              </div>
+              <span class="collection-name" style="font-style: italic;">Non classées</span>
+            </div>
+            <span class="collection-count">6</span>
+          </div>
+
+          <div class="section-separator"></div>
+
+          <div class="collection-head">
+            <span class="section-label">Collections</span>
+            <button class="btn-text" onclick="showNewCollectionModal()">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M12 5v14M5 12h14"/></svg>
+              Nouvelle
+            </button>
+          </div>
+
+          <div class="collection-item" data-collection="pictos">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <span class="collection-name">Pictos marque</span>
+            </div>
+            <span class="collection-count">12</span>
+            <button class="collection-menu" onclick="event.stopPropagation();">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+            </button>
+          </div>
+
+          <div class="collection-item" data-collection="soldes">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <span class="collection-name">Soldes Printemps 26</span>
+            </div>
+            <span class="collection-count">8</span>
+            <button class="collection-menu" onclick="event.stopPropagation();">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+            </button>
+          </div>
+
+          <div class="collection-item" data-collection="hero">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <span class="collection-name">Bannières hero</span>
+            </div>
+            <span class="collection-count">5</span>
+            <button class="collection-menu" onclick="event.stopPropagation();">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+            </button>
+          </div>
+
+          <div class="collection-item" data-collection="logos">
+            <div class="collection-left">
+              <div class="collection-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </div>
+              <span class="collection-name">Logos partenaires</span>
+            </div>
+            <span class="collection-count">4</span>
+            <button class="collection-menu" onclick="event.stopPropagation();">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/><circle cx="5" cy="12" r="1"/></svg>
+            </button>
+          </div>
+
+          <div class="section-separator"></div>
+
+          <div class="advanced-filters">
+            <div class="collection-head">
+              <span class="section-label">Affichage</span>
+            </div>
+            <div class="filter-row">
+              <label>Trier par</label>
+              <select>
+                <option>Date (récent → ancien)</option>
+                <option>Date (ancien → récent)</option>
+                <option>Nom (A → Z)</option>
+                <option>Nom (Z → A)</option>
+                <option>Usage (le plus utilisé)</option>
+              </select>
+            </div>
+            <div class="filter-row">
+              <label>Afficher</label>
+              <select>
+                <option>Vignettes</option>
+                <option>Liste</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <!-- MODE DÉTAILS -->
+        <div class="mode-details" id="modeDetails">
+          <div class="detail-preview" id="detailPreview">
+            <div class="inner" id="detailPreviewInner"></div>
+          </div>
+          <div class="detail-section">
+            <div class="detail-filename" id="detailLabel">—</div>
+            <div class="detail-subline" id="detailSubline">—</div>
+          </div>
+
+          <div class="detail-fields">
+            <div class="detail-field">
+              <span class="detail-label">Dimensions</span>
+              <span class="detail-value" id="detailDims">—</span>
+            </div>
+            <div class="detail-field">
+              <span class="detail-label">Format</span>
+              <span class="detail-value" id="detailFormat">—</span>
+            </div>
+            <div class="detail-field" id="detailWeightRow" style="display: none;">
+              <span class="detail-label">Poids</span>
+              <span class="detail-value" id="detailWeight">—</span>
+            </div>
+            <div class="detail-field">
+              <span class="detail-label">Uploadée le</span>
+              <span class="detail-value" id="detailDate">—</span>
+            </div>
+            <div class="detail-field">
+              <span class="detail-label">Par</span>
+              <span class="detail-value" id="detailAuthor">—</span>
+            </div>
+            <div class="detail-field">
+              <span class="detail-label">Usage</span>
+              <span class="detail-value" id="detailUsage">—</span>
+            </div>
+          </div>
+
+          <div class="detail-section" style="margin-top: 14px;">
+            <span class="section-label">Collections</span>
+            <div class="detail-collections-wrap" id="detailColls"></div>
+          </div>
+        </div>
+
+        <!-- MODE BULK -->
+        <div class="mode-bulk" id="modeBulk">
+          <div class="bulk-hero">
+            <div class="bulk-hero-count" id="bulkHeroCount">0</div>
+            <div class="bulk-hero-label">images sélectionnées</div>
+          </div>
+          <div class="bulk-actions-list">
+            <button class="bulk-action-item" onclick="showCollectionModal(true)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              Ajouter à une collection
+            </button>
+            <button class="bulk-action-item">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 11l-4 4 4 4M5 15h14"/></svg>
+              Retirer d'une collection
+            </button>
+            <button class="bulk-action-item">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+              Télécharger (ZIP)
+            </button>
+            <button class="bulk-action-item danger" onclick="showDeleteModal(true)">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+              Supprimer les images
+            </button>
+            <button class="bulk-action-item" onclick="clearSelection()" style="margin-top: 6px; justify-content: center; font-style: italic; color: var(--lp-text-muted);">
+              Annuler la sélection
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Actions ancrées en bas du panneau droit (mode détails uniquement) -->
+      <div class="detail-actions" id="detailActions" style="display: none;">
+        <button class="action-btn primary">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+          Éditer l'image
+        </button>
+        <button class="action-btn" onclick="showCollectionModal(false)">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+          Collections
+        </button>
+        <button class="action-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+          Renommer
+        </button>
+        <button class="action-btn">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></svg>
+          Télécharger
+        </button>
+        <button class="action-btn danger" onclick="showDeleteModal(false)" style="grid-column: span 2;">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Supprimer
+        </button>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- ============= MODALES ============= -->
+<div class="modal-backdrop" id="collectionModal">
+  <div class="modal">
+    <div class="modal-head">
+      <div class="modal-title">Gérer les collections</div>
+      <button class="modal-close" onclick="closeCollectionModal()">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p id="collectionModalDesc">Cochez les collections :</p>
+      <ul class="collection-checklist">
+        <li><input type="checkbox" id="c1" checked><label for="c1">Pictos marque</label></li>
+        <li><input type="checkbox" id="c2"><label for="c2">Soldes Printemps 26</label></li>
+        <li><input type="checkbox" id="c3"><label for="c3">Bannières hero</label></li>
+        <li><input type="checkbox" id="c4"><label for="c4">Logos partenaires</label></li>
+      </ul>
+      <div class="collection-new-inline">
+        <input type="text" placeholder="Créer une nouvelle collection...">
+        <button class="modal-btn primary">Créer</button>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeCollectionModal()">Annuler</button>
+      <button class="modal-btn primary" onclick="closeCollectionModal()">Enregistrer</button>
+    </div>
+  </div>
+</div>
+
+<div class="modal-backdrop" id="deleteModal">
+  <div class="modal">
+    <div class="modal-head">
+      <div class="modal-title" style="color: var(--lp-danger);">Supprimer ?</div>
+    </div>
+    <div class="modal-body">
+      <p id="deleteWarning" style="font-weight: 500; color: var(--lp-danger);">⚠ Cette image est utilisée dans 2 emails.</p>
+      <p>Elle sera déplacée dans la corbeille et automatiquement supprimée après 30 jours. Vous pouvez la restaurer à tout moment.</p>
+    </div>
+    <div class="modal-footer">
+      <button class="modal-btn" onclick="closeDeleteModal()">Annuler</button>
+      <button class="modal-btn danger" onclick="closeDeleteModal()">Déplacer dans la corbeille</button>
+    </div>
+  </div>
+</div>
+
+<div class="demo-tip" id="demoTip">
+  <span><strong>Maquette v2</strong> — Testez : cliquer sur une image (panneau droit en mode détails), cocher la checkbox (mode bulk), cliquer ailleurs dans le vide pour revenir aux collections.</span>
+  <button onclick="this.parentElement.style.display='none'">Compris</button>
+</div>
+
+<script>
+  // Data mock — variété d'images avec/sans fond transparent
+  const palette = [
+    ['#f7d794', '#e58e26'], ['#7ed6df', '#22a6b3'], ['#e77f67', '#cd6133'],
+    ['#778beb', '#4834d4'], ['#786fa6', '#574b90'], ['#f8a5c2', '#cc8e9e'],
+    ['#63cdda', '#3dc1d3'], ['#ea8685', '#b33939'], ['#f3a683', '#e15f41'],
+    ['#cf6a87', '#b53471'], ['#ffda79', '#ccae62'], ['#ea8685', '#c44569']
+  ];
+  const iconShapes = ['gift', 'heart', 'bag', 'tag', 'star', 'truck', 'shield', 'bell', 'diamond', 'flame', 'leaf', 'sun'];
+
+  function svgIcon(name, color, size = '55%') {
+    const icons = {
+      gift: '<rect x="4" y="10" width="24" height="18" rx="2"/><rect x="2" y="6" width="28" height="6"/><path d="M16 6v22M12 6c-2 0-4-2-4-4s2-2 4 0 4 4 4 4M20 6c2 0 4-2 4-4s-2-2-4 0-4 4-4 4"/>',
+      heart: '<path d="M16 28C8 22 3 18 3 12c0-4 3-7 7-7 2 0 4 1 6 3 2-2 4-3 6-3 4 0 7 3 7 7 0 6-5 10-13 16z"/>',
+      bag: '<path d="M6 10h20l-2 18H8L6 10z"/><path d="M11 10V6a5 5 0 0 1 10 0v4"/>',
+      tag: '<path d="M18 2l12 12-14 14L4 16V4h12z"/><circle cx="10" cy="10" r="2"/>',
+      star: '<path d="M16 3l4 9 10 1-7 7 2 10-9-5-9 5 2-10-7-7 10-1z"/>',
+      truck: '<rect x="2" y="10" width="16" height="12"/><path d="M18 14h8l4 5v3h-12z"/><circle cx="8" cy="24" r="3"/><circle cx="24" cy="24" r="3"/>',
+      shield: '<path d="M16 3l12 5v8c0 7-5 12-12 14C9 28 4 23 4 16V8z"/>',
+      bell: '<path d="M8 22V14a8 8 0 1 1 16 0v8l2 2H6z"/><path d="M13 26a3 3 0 0 0 6 0"/>',
+      diamond: '<path d="M8 4h16l6 8-14 16L2 12z"/>',
+      flame: '<path d="M16 2c4 6 10 10 10 16 0 5-4 10-10 10S6 23 6 18c0-4 3-6 5-10 2 4 4 6 5 6 0-6 0-10 0-12z"/>',
+      leaf: '<path d="M4 28c0-14 12-24 24-24 0 14-10 24-24 24z"/><path d="M4 28C10 20 18 14 28 4"/>',
+      sun: '<circle cx="16" cy="16" r="6"/><path d="M16 2v4M16 26v4M2 16h4M26 16h4M6 6l3 3M23 23l3 3M26 6l-3 3M9 23l-3 3"/>'
+    };
+    return `<svg viewBox="0 0 32 32" fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" width="${size}" height="${size}">${icons[name] || icons.star}</svg>`;
+  }
+
+  function makeImage(i) {
+    const [bg, fg] = palette[i % palette.length];
+    const shape = iconShapes[i % iconShapes.length];
+    const labels = {
+      0: 'logo_clarins_red.png',
+      1: 'picto_livraison.png',
+      2: 'picto_garantie.png',
+      3: 'cover_soldes_hiver_26.jpg',
+      4: 'produit_serum_200ml.jpg',
+      5: 'banner_hero_printemps.jpg',
+      6: 'picto_retour_gratuit.png',
+      7: 'picto_paiement_securise.png',
+      8: 'visuel_rouge_levres.jpg',
+      9: 'animation_unboxing.gif',
+      10: 'picto_newsletter.png',
+      11: 'header_mothers_day.jpg'
+    };
+    const format = ['jpg', 'png', 'gif', 'png', 'jpg'][i % 5];
+    // Les PNG ont souvent un fond transparent, les JPG ont un fond plein
+    const hasTransparency = format === 'png' || format === 'gif';
+    return {
+      id: i,
+      label: labels[i % 12] || `image_${i + 1}.${format}`,
+      bg, fg, shape, format, hasTransparency,
+      dims: ['1200 × 800 px', '600 × 600 px', '1920 × 1080 px', '400 × 400 px'][i % 4],
+      weight: '1.2 Mo',
+      date: '14 avril 2026',
+      author: ['Marie L.', 'Alex B.', 'Sophie R.', 'Thomas K.'][i % 4],
+      collections: [['Pictos marque'], ['Soldes Printemps 26'], ['Bannières hero'], [], ['Pictos marque', 'Soldes Printemps 26']][i % 5],
+      usageCount: i % 3 === 0 ? 2 : (i % 3 === 1 ? 1 : 0)
+    };
+  }
+
+  let images = [];
+  for (let i = 0; i < 42; i++) images.push(makeImage(i));
+
+  let currentTab = 'template';
+  let selectedIds = new Set();
+  let currentCollection = 'all';
+  let currentDetailId = null;
+  let currentMode = 'collections'; // 'collections' | 'details' | 'bulk'
+
+  // ========== RENDU ==========
+  function renderGrid() {
+    const grid = document.getElementById('grid');
+    const metaCount = document.getElementById('metaCount');
+    let filtered;
+    if (currentTab === 'email') {
+      filtered = images.slice(0, 4);
+    } else {
+      if (currentCollection === 'unclassified') {
+        filtered = images.filter(im => im.collections.length === 0);
+      } else if (currentCollection !== 'all') {
+        const collMap = { pictos: 'Pictos marque', soldes: 'Soldes Printemps 26', hero: 'Bannières hero', logos: 'Logos partenaires' };
+        filtered = images.filter(im => im.collections.includes(collMap[currentCollection]));
+      } else {
+        filtered = images;
+      }
+    }
+    if (filtered.length === 0) {
+      grid.innerHTML = `<div style="grid-column: 1/-1;" class="empty-state">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+        <div class="empty-state-title">Aucune image</div>
+        <div class="empty-state-msg">Déposez ou uploadez pour commencer.</div>
+      </div>`;
+      metaCount.textContent = '0 image';
+      return;
+    }
+    grid.innerHTML = filtered.map(img => {
+      const isSelected = selectedIds.has(img.id);
+      const isHighlighted = currentDetailId === img.id;
+      const isGif = img.format === 'gif';
+      const thumbBg = img.hasTransparency ? '' : 'solid';
+      const innerBg = img.hasTransparency ? '' : `background: linear-gradient(135deg, ${img.bg}44, ${img.bg}88);`;
+      return `
+        <div class="thumb ${isSelected ? 'selected' : ''} ${isHighlighted ? 'highlighted' : ''}" data-id="${img.id}" onclick="onThumbClick(event, ${img.id})">
+          <div class="thumb-check ${isSelected ? 'checked' : ''}" onclick="event.stopPropagation(); toggleSelect(${img.id})">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+          </div>
+          ${isGif ? '<div class="thumb-badge gif">GIF</div>' : ''}
+          <div class="thumb-img ${thumbBg}">
+            <div class="thumb-img-inner" style="${innerBg}">
+              ${svgIcon(img.shape, img.fg, '60%')}
+            </div>
+          </div>
+          <div class="thumb-label" title="${img.label}">${img.label}</div>
+          <div class="thumb-overlay">
+            <div class="thumb-actions">
+              <button class="thumb-action" title="Éditer" onclick="event.stopPropagation(); alert('Relance de l\\'éditeur Konva')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+              </button>
+              <button class="thumb-action" title="Collections" onclick="event.stopPropagation(); showCollectionModal(false)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+              </button>
+              <button class="thumb-action danger" title="Supprimer" onclick="event.stopPropagation(); showDeleteModal(false)">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+    metaCount.textContent = `${filtered.length} image${filtered.length > 1 ? 's' : ''}`;
+  }
+
+  // ========== MODES DU PANNEAU DROIT ==========
+  function switchMode(mode) {
+    currentMode = mode;
+    document.getElementById('modeCollections').classList.toggle('hidden', mode !== 'collections');
+    document.getElementById('modeDetails').classList.toggle('visible', mode === 'details');
+    document.getElementById('modeBulk').classList.toggle('visible', mode === 'bulk');
+    document.getElementById('detailActions').style.display = mode === 'details' ? 'grid' : 'none';
+    const title = document.getElementById('rightTitle');
+    const badge = document.getElementById('rightModeBadge');
+    if (mode === 'collections') { title.textContent = 'Collections'; badge.textContent = 'Navigation'; }
+    if (mode === 'details') { title.textContent = 'Détails de l\'image'; badge.textContent = 'Image sélectionnée'; }
+    if (mode === 'bulk') { title.textContent = 'Sélection'; badge.textContent = 'Actions groupées'; }
+  }
+
+  // ========== INTERACTIONS ==========
+  function onThumbClick(e, id) {
+    if (e.shiftKey || selectedIds.size > 0) {
+      toggleSelect(id);
+      return;
+    }
+    // Ouvre les détails dans le panneau droit
+    currentDetailId = id;
+    renderDetails(id);
+    switchMode('details');
+    renderGrid(); // pour le highlight
+  }
+
+  function toggleSelect(id) {
+    if (selectedIds.has(id)) selectedIds.delete(id);
+    else selectedIds.add(id);
+    renderGrid();
+    updateBulkUI();
+  }
+
+  function clearSelection() {
+    selectedIds.clear();
+    renderGrid();
+    updateBulkUI();
+  }
+
+  function updateBulkUI() {
+    const bar = document.getElementById('bulkBar');
+    if (selectedIds.size > 0) {
+      bar.classList.add('visible');
+      document.getElementById('bulkCountLeft').textContent = selectedIds.size;
+      document.getElementById('bulkHeroCount').textContent = selectedIds.size;
+      switchMode('bulk');
+    } else {
+      bar.classList.remove('visible');
+      if (currentMode === 'bulk') {
+        if (currentDetailId !== null) { switchMode('details'); }
+        else switchMode('collections');
+      }
+    }
+  }
+
+  function renderDetails(id) {
+    const img = images[id];
+    document.getElementById('detailLabel').textContent = img.label;
+    document.getElementById('detailSubline').textContent = `Uploadée par ${img.author} · ${img.date}`;
+    document.getElementById('detailDims').textContent = img.dims;
+    document.getElementById('detailFormat').textContent = img.format.toUpperCase();
+    document.getElementById('detailDate').textContent = img.date;
+    document.getElementById('detailAuthor').textContent = img.author;
+
+    const weightRow = document.getElementById('detailWeightRow');
+    if (img.format === 'gif') {
+      weightRow.style.display = 'flex';
+      document.getElementById('detailWeight').textContent = img.weight;
+    } else {
+      weightRow.style.display = 'none';
+    }
+
+    const colls = document.getElementById('detailColls');
+    if (img.collections.length === 0) {
+      colls.innerHTML = '<span style="color: var(--lp-text-faint); font-style: italic; font-size: 11px;">Non classée</span>';
+    } else {
+      colls.innerHTML = img.collections.map(c => `<span class="detail-coll-pill">${c}</span>`).join('');
+    }
+
+    const usage = document.getElementById('detailUsage');
+    if (img.usageCount === 0) {
+      usage.innerHTML = '<span class="usage-pill unused">Non utilisée</span>';
+    } else {
+      usage.innerHTML = `<span class="usage-pill used">Utilisée dans ${img.usageCount} email${img.usageCount > 1 ? 's' : ''}</span>`;
+    }
+
+    // Preview
+    const preview = document.getElementById('detailPreview');
+    const inner = document.getElementById('detailPreviewInner');
+    preview.classList.toggle('solid', !img.hasTransparency);
+    if (img.hasTransparency) {
+      inner.style.background = '';
+    } else {
+      inner.style.background = `linear-gradient(135deg, ${img.bg}44, ${img.bg}88)`;
+    }
+    inner.innerHTML = svgIcon(img.shape, img.fg, '70%');
+  }
+
+  // Click sur le vide → revenir aux collections
+  document.querySelector('.email-canvas').addEventListener('click', () => {
+    if (selectedIds.size === 0 && currentMode === 'details') {
+      currentDetailId = null;
+      switchMode('collections');
+      renderGrid();
+    }
+  });
+
+  function showCollectionModal(bulk) {
+    document.getElementById('collectionModalDesc').textContent = bulk
+      ? `Ajouter les ${selectedIds.size} images sélectionnées à une collection :`
+      : 'Cochez les collections pour cette image :';
+    document.getElementById('collectionModal').classList.add('visible');
+  }
+  function closeCollectionModal() { document.getElementById('collectionModal').classList.remove('visible'); }
+  function showNewCollectionModal() { showCollectionModal(false); }
+  function showDeleteModal(bulk) {
+    const warning = document.getElementById('deleteWarning');
+    warning.textContent = bulk
+      ? `⚠ ${selectedIds.size} image(s) sélectionnée(s). Certaines sont utilisées dans des emails.`
+      : '⚠ Cette image est utilisée dans 2 emails.';
+    document.getElementById('deleteModal').classList.add('visible');
+  }
+  function closeDeleteModal() { document.getElementById('deleteModal').classList.remove('visible'); }
+
+  // Bindings
+  document.querySelectorAll('.sub-tab').forEach(t => {
+    t.addEventListener('click', () => {
+      document.querySelectorAll('.sub-tab').forEach(x => x.classList.remove('active'));
+      t.classList.add('active');
+      currentTab = t.dataset.tab;
+      selectedIds.clear();
+      currentDetailId = null;
+      switchMode('collections');
+      renderGrid();
+    });
+  });
+
+  document.querySelectorAll('.collection-item').forEach(item => {
+    item.addEventListener('click', () => {
+      document.querySelectorAll('.collection-item').forEach(x => x.classList.remove('active'));
+      item.classList.add('active');
+      currentCollection = item.dataset.collection;
+      renderGrid();
+    });
+  });
+
+  document.querySelectorAll('.filter-chip').forEach(f => {
+    f.addEventListener('click', () => {
+      document.querySelectorAll('.filter-chip').forEach(x => x.classList.remove('active'));
+      f.classList.add('active');
+    });
+  });
+
+  document.getElementById('selectAllBtn').addEventListener('click', () => {
+    const visibleImages = currentTab === 'email' ? images.slice(0, 4) : images;
+    if (selectedIds.size === visibleImages.length) {
+      selectedIds.clear();
+    } else {
+      visibleImages.forEach(im => selectedIds.add(im.id));
+    }
+    renderGrid();
+    updateBulkUI();
+  });
+
+  renderGrid();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Contexte

Mise en place de la documentation et des références pour le chantier de refonte de la galerie d'images (V1).

Ce chantier est cadré pour livrer une amélioration significative de la galerie sur 3 axes principaux : refonte UI/UX, recherche, édition rétroactive. Le périmètre V1 est volontairement resserré pour livrer vite. Les fonctionnalités plus ambitieuses (collections, panneau droit, bulk, soft delete) sont reportées en V2+.

## Contenu de cette PR

- `CLAUDE.md` à la racine : contexte complet du chantier pour Claude Code
- `docs/gallery-redesign/USER_STORIES.md` : découpage opérationnel en 7 user stories (~9 jours estimés)
- `docs/gallery-redesign/mockup-v1.html` : maquette de référence V1 (galerie en panneau gauche unique)
- `docs/gallery-redesign/mockup-v2.html` : maquette cible V2 future (architecture split, à ne pas implémenter en V1)

## Pas de changement de code

Cette PR ne contient que de la documentation. Le dev démarrera sur des branches `feat/gallery-redesign-XX-*` à partir de develop, une fois cette PR mergée.

## À reviewer

- La cohérence du périmètre V1 décrit
- L'organisation des fichiers dans `docs/gallery-redesign/`
- Les conventions proposées dans `CLAUDE.md` (branches, commits, tests)