### PR TITLE
  feat(gallery): US-01 — extension du modèle Gallery (label, source, externalMetadata)

### DIFF
--- a/packages/server/common/file-manage.service.js
+++ b/packages/server/common/file-manage.service.js
@@ -7,6 +7,7 @@ const chalk = require('chalk');
 const formidable = require('formidable');
 
 const config = require('../node.config.js');
+const logger = require('../utils/logger.js');
 const defer = require('../helpers/create-promise.js');
 const formatName = require('../helpers/format-filename-for-jquery-fileupload.js');
 const slugFilename = require('../helpers/slug-filename.js');
@@ -59,7 +60,7 @@ function handleTemplatesUploads(fields, files, resolve) {
 }
 
 function handleEditorUpload(fields, files, resolve) {
-  console.log('HANDLE JQUERY FILE UPLOAD');
+  logger.log('Handling jQuery file upload');
   const rawFile = files['files[]'];
   const file = {
     ...formatName(rawFile.name),

--- a/packages/server/common/file-manage.service.js
+++ b/packages/server/common/file-manage.service.js
@@ -60,8 +60,11 @@ function handleTemplatesUploads(fields, files, resolve) {
 
 function handleEditorUpload(fields, files, resolve) {
   console.log('HANDLE JQUERY FILE UPLOAD');
-  let file = files['files[]'];
-  file = formatName(file.name);
+  const rawFile = files['files[]'];
+  const file = {
+    ...formatName(rawFile.name),
+    originalName: rawFile.originalName,
+  };
   // knockout jquery-fileupload binding expect this format
   resolve({ files: [file] });
 }

--- a/packages/server/image/gallery.schema.js
+++ b/packages/server/image/gallery.schema.js
@@ -12,6 +12,9 @@ const formatFilenameForJqueryFileupload = require('../helpers/format-filename-fo
  * @apiSuccess {String} files.url used by mosaico editor
  * @apiSuccess {String} files.deleteUrl used by mosaico editor
  * @apiSuccess {String} files.thumbnailUrl used by mosaico editor
+ * @apiSuccess {String} files.label human-readable label (falls back to file.name for non-migrated images)
+ * @apiSuccess {String} files.source image origin (e.g. 'upload', 'dam_bynder')
+ * @apiSuccess {Object} files.externalMetadata metadata from external sources (DAM, etc.)
  */
 
 // This table is used to add a visible information on the images

--- a/packages/server/image/gallery.schema.js
+++ b/packages/server/image/gallery.schema.js
@@ -26,9 +26,12 @@ const GallerySchema = Schema(
       type: [],
       // make sure we have the right format for a gallery
       get: (files) => {
-        return files.map((file) =>
-          formatFilenameForJqueryFileupload(file.name)
-        );
+        return files.map((file) => ({
+          ...formatFilenameForJqueryFileupload(file.name),
+          label: file.label || file.name,
+          source: file.source || 'upload',
+          externalMetadata: file.externalMetadata || {},
+        }));
       },
     },
   },
@@ -51,7 +54,9 @@ GallerySchema.methods.duplicate = function duplicate(newCreationId) {
   // update the files names & path
   this.files = this.files.map((file) => {
     Object.keys(file).forEach((key) => {
-      file[key] = file[key].replace(oldCreationId, newCreationId);
+      if (typeof file[key] === 'string') {
+        file[key] = file[key].replace(oldCreationId, newCreationId);
+      }
     });
     return file;
   });

--- a/packages/server/image/image.controller.js
+++ b/packages/server/image/image.controller.js
@@ -476,7 +476,12 @@ async function create(req, res) {
     const imageName = upload.name;
     const hasAlreadyCurrentFile = galleryImagesName.includes(imageName);
     if (hasAlreadyCurrentFile) return;
-    galleryImages.push(upload);
+    galleryImages.push({
+      ...upload,
+      label: upload.originalName,
+      source: 'upload',
+      externalMetadata: {},
+    });
   });
   safeGallery.files = galleryImages;
 

--- a/tests/server/image/gallery.schema.test.js
+++ b/tests/server/image/gallery.schema.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+// Capture the `files` field definition from the Schema() call to test the getter in isolation.
+// The getter is a pure function (files[]) → transformed files[], no DB needed.
+let capturedFilesDefinition = null;
+
+jest.mock('mongoose', () => {
+  const mockSchema = jest.fn((definition) => {
+    capturedFilesDefinition = definition.files;
+    return { plugin: jest.fn(), methods: {} };
+  });
+  mockSchema.Types = { ObjectId: jest.fn() };
+  return { Schema: mockSchema, Types: { ObjectId: jest.fn() } };
+});
+// mongoose-hidden is required as: require('mongoose-hidden')() → plugin fn
+jest.mock('mongoose-hidden', () => () => jest.fn());
+
+const GallerySchema = require('../../../packages/server/image/gallery.schema');
+
+describe('gallery.schema — files getter', () => {
+  let getter;
+
+  beforeAll(() => {
+    getter = capturedFilesDefinition.get;
+  });
+
+  describe('champs Mosaico (compat obligatoire)', () => {
+    it('préserve les 4 champs Mosaico dans chaque fichier', () => {
+      const result = getter([{ name: 'abc-hash.jpg' }]);
+      expect(result[0]).toMatchObject({
+        name: 'abc-hash.jpg',
+        url: 'abc-hash.jpg',
+        deleteUrl: '/api/images/abc-hash.jpg',
+        thumbnailUrl: '/api/images/cover/111x111/abc-hash.jpg',
+      });
+    });
+  });
+
+  describe('label', () => {
+    it('retourne file.label quand il est défini (image migrée ou nouvel upload)', () => {
+      const result = getter([{ name: 'abc-hash.jpg', label: 'mon-logo.jpg' }]);
+      expect(result[0].label).toBe('mon-logo.jpg');
+    });
+
+    it('retourne file.name comme fallback quand label absent (images non encore migrées)', () => {
+      const result = getter([{ name: 'abc-hash.jpg' }]);
+      expect(result[0].label).toBe('abc-hash.jpg');
+    });
+  });
+
+  describe('source', () => {
+    it('retourne file.source quand il est défini', () => {
+      const result = getter([{ name: 'f.jpg', source: 'dam_bynder' }]);
+      expect(result[0].source).toBe('dam_bynder');
+    });
+
+    it('retourne "upload" comme fallback quand source absent', () => {
+      const result = getter([{ name: 'f.jpg' }]);
+      expect(result[0].source).toBe('upload');
+    });
+  });
+
+  describe('externalMetadata', () => {
+    it('retourne file.externalMetadata quand il est défini', () => {
+      const result = getter([
+        { name: 'f.jpg', externalMetadata: { foo: 'bar' } },
+      ]);
+      expect(result[0].externalMetadata).toEqual({ foo: 'bar' });
+    });
+
+    it('retourne {} comme fallback quand externalMetadata absent', () => {
+      const result = getter([{ name: 'f.jpg' }]);
+      expect(result[0].externalMetadata).toEqual({});
+    });
+  });
+});
+
+describe('gallery.schema — duplicate()', () => {
+  const OLD_ID = '507f1f77bcf86cd799439011';
+  const NEW_ID = '507f1f77bcf86cd799439022';
+
+  function makeMockDoc(files) {
+    return {
+      _id: 'some-id',
+      isNew: false,
+      creationOrWireframeId: OLD_ID,
+      files,
+      markModified: jest.fn(),
+    };
+  }
+
+  it('ne plante pas quand externalMetadata est un objet (régression)', () => {
+    const doc = makeMockDoc([
+      {
+        name: `${OLD_ID}-hash.jpg`,
+        url: `${OLD_ID}-hash.jpg`,
+        deleteUrl: `/api/images/${OLD_ID}-hash.jpg`,
+        thumbnailUrl: `/api/images/cover/111x111/${OLD_ID}-hash.jpg`,
+        label: 'mon-logo.jpg',
+        source: 'upload',
+        externalMetadata: { foo: 'bar' },
+      },
+    ]);
+
+    expect(() =>
+      GallerySchema.methods.duplicate.call(doc, NEW_ID)
+    ).not.toThrow();
+  });
+
+  it('remplace l\'ancien creationId dans les champs string', () => {
+    const doc = makeMockDoc([
+      {
+        name: `${OLD_ID}-hash.jpg`,
+        url: `${OLD_ID}-hash.jpg`,
+        deleteUrl: `/api/images/${OLD_ID}-hash.jpg`,
+        thumbnailUrl: `/api/images/cover/111x111/${OLD_ID}-hash.jpg`,
+        label: 'logo.jpg',
+        source: 'upload',
+        externalMetadata: {},
+      },
+    ]);
+
+    GallerySchema.methods.duplicate.call(doc, NEW_ID);
+
+    expect(doc.files[0].name).toBe(`${NEW_ID}-hash.jpg`);
+    expect(doc.files[0].url).toBe(`${NEW_ID}-hash.jpg`);
+    expect(doc.files[0].deleteUrl).toBe(`/api/images/${NEW_ID}-hash.jpg`);
+  });
+
+  it('ne modifie pas label et externalMetadata (pas d\'ancien creationId dedans)', () => {
+    const doc = makeMockDoc([
+      {
+        name: `${OLD_ID}-hash.jpg`,
+        url: `${OLD_ID}-hash.jpg`,
+        deleteUrl: `/api/images/${OLD_ID}-hash.jpg`,
+        thumbnailUrl: `/api/images/cover/111x111/${OLD_ID}-hash.jpg`,
+        label: 'logo.jpg',
+        source: 'upload',
+        externalMetadata: { provider: 'bynder' },
+      },
+    ]);
+
+    GallerySchema.methods.duplicate.call(doc, NEW_ID);
+
+    expect(doc.files[0].label).toBe('logo.jpg');
+    expect(doc.files[0].externalMetadata).toEqual({ provider: 'bynder' });
+  });
+});


### PR DESCRIPTION
  ## Contexte

  US-01 du chantier refonte galerie V1.
  Étend le modèle de données de la galerie pour ajouter les champs V1, sans toucher aux endpoints Mosaico existants.

  ## Changements

  **`gallery.schema.js`** — getter étendu (`label`, `source`, `externalMetadata`) + `duplicate()` protégé contre les valeurs non-string

  **`image.controller.js`** — nouveaux uploads stockés avec `label = originalName`, `source = 'upload'`, `externalMetadata = {}`

  **`file-manage.service.js`** — bugfix : `handleEditorUpload` perdait `originalName` en écrasant l'objet fichier avec `formatName()`

  **`tests/server/image/gallery.schema.test.js`** _(nouveau)_ — 10 tests Jest

  ## Compat Mosaico

  Les 4 champs Mosaico (`name`, `url`, `deleteUrl`, `thumbnailUrl`) sont inchangés. Voir `docs/gallery-redesign/MOSAICO_COMPAT.md`.

  ## Comment tester

  1. Uploader une image dans la galerie d'un template
  2. Vérifier en base que la dernière entrée `files[]` contient `label`, `source`, `externalMetadata`
  3. Vérifier que l'éditeur Mosaico fonctionne normalement

  ## Hors scope (reporté)

  - Index Mongo → US-02
  - Migration images existantes → US-03