### PR TITLE
fix(dashboard): corrige le 500 à l'ajout d'un tableau de bord (integrationId undefined)

### DIFF
--- a/packages/server/dashboard/dashboard.service.js
+++ b/packages/server/dashboard/dashboard.service.js
@@ -93,6 +93,10 @@ async function createDashboard(groupId, data) {
     lockedParams,
   } = data;
 
+  if (!Types.ObjectId.isValid(integrationId)) {
+    throw createError(400, ERROR_CODES.INVALID_INTEGRATION);
+  }
+
   // Validate integration exists and belongs to the same group
   const integration = await Integrations.findOne({
     _id: Types.ObjectId(integrationId),
@@ -159,6 +163,10 @@ async function updateDashboard(dashboardId, data) {
 
   // If changing integration, validate it exists and belongs to the same group
   if (integrationId && integrationId !== dashboard._integration.toString()) {
+    if (!Types.ObjectId.isValid(integrationId)) {
+      throw createError(400, ERROR_CODES.INVALID_INTEGRATION);
+    }
+
     const integration = await Integrations.findOne({
       _id: Types.ObjectId(integrationId),
       _company: dashboard._company,

--- a/packages/server/integration/integration.controller.js
+++ b/packages/server/integration/integration.controller.js
@@ -28,6 +28,7 @@ const UPDATE_FIELDS = [...CREATE_FIELDS, 'isActive'];
 // instead of passing the Mongoose document to `res.json`.
 const RESPONSE_FIELDS = [
   '_id',
+  'id',
   'name',
   'type',
   'provider',


### PR DESCRIPTION
## Problème

À l'ajout d'un tableau de bord (intégration active, connexion vérifiée), l'API renvoyait :

```
500 — Argument passed in must be a single String of 12 bytes or a string of 24 hex characters
```

## Cause

Le DTO d'intégration (`toIntegrationDto`) ne whitelistait que `_id` dans `RESPONSE_FIELDS`, pas le virtual Mongoose `id`. Comme `pick()` ne recopie que les clés listées, `id` était supprimé de la réponse API.

Côté front, la v-select utilise `item-value="id"` et tout le code attend `integration.id`. Résultat : `form.integrationId` valait `undefined`, et `Types.ObjectId(undefined)` levait le 500.

## Correctifs

- **`integration.controller.js`** — ajout de `'id'` à `RESPONSE_FIELDS`. Le virtual `id` (stringification de `_id`) atteint maintenant le front. → **fix du symptôme**.
- **`dashboard.service.js`** — garde `Types.ObjectId.isValid()` dans `createDashboard` et `updateDashboard` : renvoie un `400 INVALID_INTEGRATION` propre au lieu d'un 500 brut sur un id invalide. → **durcissement**.

## Tests

- ESLint OK sur les fichiers modifiés.
- À valider manuellement : ajout d'un tableau de bord avec une intégration active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)