### PR TITLE
fix(mailing): permet la copie d'une créa depuis un workspace en consultation seule

### DIFF
--- a/packages/server/mailing/mailing.service.js
+++ b/packages/server/mailing/mailing.service.js
@@ -1027,14 +1027,20 @@ async function copyMailing(mailingId, destination, user) {
   // group by id (cross-tenant IDOR).
   const mailing = await findOneForUser(mailingId, user);
 
-  if (mailing?._parentFolder) {
-    await folderService.hasAccess(mailing._parentFolder, user);
-  }
+  // Copying is a READ operation on the source: a regular_user with
+  // consultation-only rights on the source workspace must be able to copy a
+  // mailing out of it. We therefore only require READ access on the source
+  // workspace — `folderService.hasAccess` would require workspace membership
+  // (write), which wrongly blocked read-only users copying from a folder.
+  // A mailing lives in either a workspace or a folder (never both); when it is
+  // in a folder, resolve the owning workspace to run the same read check.
+  const sourceWorkspace = mailing?._parentFolder
+    ? await folderService.getWorkspaceForFolder(mailing._parentFolder)
+    : mailing?.workspace
+    ? await workspaceService.getWorkspace(mailing.workspace)
+    : null;
 
-  if (mailing?.workspace) {
-    const sourceWorkspace = await workspaceService.getWorkspace(
-      mailing.workspace
-    );
+  if (sourceWorkspace) {
     workspaceService.doesUserHaveReadAccess(user, sourceWorkspace);
   }
 


### PR DESCRIPTION
## Problème

Profil `regular_user`. Si l'utilisateur sélectionne une créa email dans un workspace auquel il n'est **pas assigné** (droit de consultation uniquement), il peut bien choisir de la dupliquer vers ses propres workspaces/folders, mais l'opération **tombe en erreur (KO)**.

## Cause

Dans `copyMailing` ([mailing.service.js](packages/server/mailing/mailing.service.js)), le code appelait `folderService.hasAccess(mailing._parentFolder, user)` sur le folder **source**.

Or `folderService.hasAccess` exige `isUserWorkspaceMember` (= accès **write / membre du workspace**). Un utilisateur en consultation seule n'est pas membre → `NotFound WORKSPACE_NOT_FOUND` → KO.

C'était une vérification **write** appliquée à tort sur la **source** d'une copie, alors qu'une copie n'est qu'une opération de **lecture** côté source.

## Correctif

On ne requiert désormais qu'un accès en **lecture** (`doesUserHaveReadAccess`) sur le workspace source, en résolvant le workspace propriétaire que la créa soit rangée dans un workspace ou dans un folder.

Aucun risque d'IDOR introduit :
- `findOneForUser` filtre déjà la créa par groupe (pas de lecture cross-tenant) ;
- la **destination** reste protégée par `doesUserHaveWriteAccess` (workspace) et `folderService.hasAccess` (folder) — inchangés.

## Tests

- ESLint OK sur le fichier modifié.
- À valider manuellement : un `regular_user` copie une créa depuis un workspace qu'il consulte seulement vers son propre workspace/folder → succès.

🤖 Generated with [Claude Code](https://claude.com/claude-code)