### PR TITLE
fix(editor): picker chromedevtool pour un input hex utilisable

### DIFF
--- a/packages/editor/src/css/badsender-colorpicker.less
+++ b/packages/editor/src/css/badsender-colorpicker.less
@@ -67,10 +67,10 @@
 .easylogic-colorpicker .colorpicker-body > .control > .hue > .hue-container {
   height: 24px;
 }
-.easylogic-colorpicker.sketch > .colorpicker-body > .control .drag-bar {
+.easylogic-colorpicker.chromedevtool > .colorpicker-body > .control .drag-bar {
   height: 75%;
 }
-.easylogic-colorpicker.sketch > .colorpicker-body > .control > .opacity {
+.easylogic-colorpicker.chromedevtool > .colorpicker-body > .control > .opacity {
   display: none;
 }
 // Fix context menu placement

--- a/packages/editor/src/js/bindings/badsender-colorpicker.js
+++ b/packages/editor/src/js/bindings/badsender-colorpicker.js
@@ -56,7 +56,7 @@ const colorpicker = {
       container: $picker,
       position: `inline`,
       autoHide: false,
-      type: `sketch`,
+      type: `chromedevtool`,
       onChange: (color) => {
         $bucket.style.backgroundColor = color;
         va.color(color);


### PR DESCRIPTION
## Problème

Sur le color picker de l'éditeur, on ne pouvait plus saisir directement le code hexadécimal : l'input texte était trop petit et fonctionnait mal. Le picker de l'admin (réglages de couleurs du groupe) était lui mieux adapté.

## Cause

Les deux pickers utilisent **la même librairie** (`@easylogic/colorpicker`) et **la même classe** sous-jacente. La seule différence était l'option `type` :

- **Admin** : `type: 'chromedevtool'` → champ hex pleine taille + sélecteur de format HEX/RGB/HSL.
- **Éditeur** : `type: 'sketch'` → le CSS `.sketch` de la lib force le champ hex à `width: 74px` et masque le sélecteur de format → d'où la saisie difficile.

## Solution

On bascule le picker de l'éditeur sur `chromedevtool` pour qu'il soit identique à celui de l'admin partout.

### Changements
- `packages/editor/src/js/bindings/badsender-colorpicker.js` — `type` passé de `sketch` à `chromedevtool`.
- `packages/editor/src/css/badsender-colorpicker.less` — les 2 overrides ciblés sur `.sketch` (masquage de l'opacité, taille de la drag-bar) re-ciblés sur `.chromedevtool` pour rester actifs.

> ℹ️ Le bundle éditeur doit être rebuild (`yarn editor:build`) pour voir le rendu dans l'app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)