### PR TITLE
fix(adobe): export images dans les deliveries (pstrUrl => [object Object])

### DIFF
--- a/packages/server/esp/adobe/adobeProvider.js
+++ b/packages/server/esp/adobe/adobeProvider.js
@@ -548,8 +548,17 @@ class AdobeProvider {
           </document>
         </m:GetURL>
       `,
-      formatResponseFn: (response) =>
-        response['SOAP-ENV:Envelope']['SOAP-ENV:Body'].GetURLResponse.pstrUrl,
+      formatResponseFn: (response) => {
+        const pstrUrl =
+          response['SOAP-ENV:Envelope']['SOAP-ENV:Body'].GetURLResponse.pstrUrl;
+        // Adobe returns <pstrUrl xsi:type="xsd:string">URL</pstrUrl>. Because the
+        // element carries the xsi:type attribute, fast-xml-parser yields an object
+        // { '#text': URL, 'xsi:type': 'xsd:string' } instead of a plain string.
+        // Read the text node when present, otherwise the value is already a string.
+        return typeof pstrUrl === 'object' && pstrUrl !== null
+          ? pstrUrl['#text']
+          : pstrUrl;
+      },
     });
   }
 


### PR DESCRIPTION
## Problème

Lors de l'export d'un mail vers Adobe Campaign, **aucune image ne s'affichait** : le HTML du delivery contenait des `src="[object Object]png"` au lieu des vraies URLs CDN Adobe. En conséquence, les images n'étaient jamais uploadées/publiées côté Adobe.

## Cause racine

`getImageUrl` lisait `GetURLResponse.pstrUrl` directement. Or Adobe renvoie :

```xml
<pstrUrl xsi:type='xsd:string'>https://...adobe-campaign.com/res/tracking/<md5>.</pstrUrl>
```

Depuis l'upgrade Node 18, le parsing XML est passé à `fast-xml-parser` avec `ignoreAttributes: false`. Un élément qui porte un attribut (ici `xsi:type`) n'est **plus** réduit à une string mais parsé en objet :

```js
{ '#text': 'https://...', 'xsi:type': 'xsd:string' }
```

Cet objet était ensuite interpolé dans le `src` via `` `${url}${tag}` `` → `[object Object]png`.

Ce n'est **pas** un changement de réponse d'Adobe (la réponse est identique, vérifiée dans Insomnia), mais un effet de bord du changement de lib XML lors de la migration Node 18.

## Fix

`getImageUrl` lit désormais `pstrUrl['#text']` quand `pstrUrl` est un objet, avec fallback string pour compatibilité.

## Vérifications

- ✅ Diagnostiqué via logs serveur : le HTML reçu de l'éditeur est propre (vraies URLs), la corruption était bien dans `getImageUrl`.
- ✅ Toute la chaîne Adobe (upload / save / publish / GetURL) fonctionne — seule l'extraction de l'URL était cassée.
- ✅ Les autres `formatResponseFn` du fichier (`getUserGroups`, `getFoldersFromGroupNames`, `getDeliveriesFromFolderFullNameOrInternalName`) lisent des **attributs** (pas de nœud texte avec `xsi:type`) → non affectés.
- ✅ Testé manuellement : après le fix, les images sont bien exportées et s'affichent dans Adobe Campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)