### PR TITLE
feat(modals): agrandir les modales avec arborescence pour faciliter la sélection

### DIFF
--- a/packages/editor/src/css/badsender-modal.less
+++ b/packages/editor/src/css/badsender-modal.less
@@ -468,7 +468,9 @@
 .bs-modal-overlay {
   // Smart Tree component styling for Adobe modal
   smart-tree {
-    --smart-tree-default-height: 300px;
+    // Grow the trees to fill the tall full-width Adobe modal so users can see
+    // many folders/deliveries at once. Caps at 60vh on short screens.
+    --smart-tree-default-height: min(60vh, 560px);
     border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }

--- a/packages/ui/components/mailings/modal-duplicate-translate.vue
+++ b/packages/ui/components/mailings/modal-duplicate-translate.vue
@@ -383,7 +383,7 @@ export default {
 </script>
 
 <template>
-  <v-dialog v-model="show" max-width="550" persistent>
+  <v-dialog v-model="show" max-width="650" persistent>
     <v-card>
       <v-card-title class="d-flex align-center">
         <lucide-languages
@@ -596,7 +596,7 @@ export default {
 
 <style lang="scss" scoped>
 .destination-tree {
-  max-height: 200px;
+  max-height: 50vh;
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/folder-move-modal.vue
+++ b/packages/ui/routes/mailings/__partials/folder-move-modal.vue
@@ -83,6 +83,7 @@ export default {
     ref="moveFolderDialog"
     :title="$t('global.moveFolderAction')"
     :is-form="true"
+    modal-width="650"
     class="modal-confirm-move-mail"
     @click-outside="close"
   >
@@ -163,7 +164,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so all
    destination-picker actions share the visual pattern. */
 .destination-tree {
-  max-height: 200px;
+  max-height: 50vh;
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
@@ -61,6 +61,7 @@ export default {
     ref="copyMailDialog"
     :title="$t('global.copyMail')"
     :is-form="true"
+    modal-width="650"
     class="modal-confirm-copy-mail"
     @click-outside="close"
   >
@@ -141,7 +142,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so all
    destination-picker actions share the visual pattern. */
 .destination-tree {
-  max-height: 200px;
+  max-height: 50vh;
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
@@ -83,6 +83,7 @@ export default {
     ref="moveMailDialog"
     :title="moveLabelButton"
     :is-form="true"
+    modal-width="650"
     class="modal-confirm-move-mail"
     @click-outside="close"
   >
@@ -163,7 +164,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so both
    actions share the visual pattern. */
 .destination-tree {
-  max-height: 200px;
+  max-height: 50vh;
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;


### PR DESCRIPTION
## Contexte

Les modales de **copie / déplacement** d'un mail (et toutes celles contenant une arborescence workspace/dossier) étaient trop petites : largeur ~500px et arbre plafonné à 200px de haut, ce qui rendait la sélection d'une destination peu confortable dès qu'il y a plusieurs workspaces / sous-dossiers.

## Changements

| Modale | Avant | Après |
|---|---|---|
| Déplacer un mail (`mailings-move-modal`) | 500px / arbre 200px | 650px / arbre `50vh` |
| Copier un mail (`mailings-copy-modal`) | 500px / arbre 200px | 650px / arbre `50vh` |
| Déplacer un dossier (`folder-move-modal`) | 500px / arbre 200px | 650px / arbre `50vh` |
| Dupliquer & traduire (`modal-duplicate-translate`) | 550px / arbre 200px | 650px / arbre `50vh` |
| Export Adobe — 2 smart-trees (`badsender-modal.less`) | 300px fixe | `min(60vh, 560px)` |

- La largeur des 4 modales Vuetify passe par le prop `modal-width` (ou `max-width` pour duplicate-translate).
- La hauteur de l'arbre devient relative au viewport (`50vh`) au lieu d'un pixel fixe : l'arbre remplit l'espace vertical disponible et scrolle au-delà.
- La modale Adobe est déjà en pleine largeur ; seul le levier pertinent (hauteur des deux smart-trees) est augmenté.

## Test

- Ouvrir une modale Copier / Déplacer depuis la liste des mailings : l'arbre est nettement plus grand et confortable.
- Vérifier la modale Export Adobe (les deux arbres folder + delivery) : hauteur augmentée.

> ℹ️ Le package `editor` (LESS) nécessite un rebuild pour voir l'effet de la modale Adobe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)