### PR TITLE
fix(modals): lazy-load des sous-dossiers dans les modales de destination

### DIFF
--- a/packages/ui/components/mailings/modal-duplicate-translate.vue
+++ b/packages/ui/components/mailings/modal-duplicate-translate.vue
@@ -526,6 +526,7 @@ export default {
                       :items="treeviewWorkspacesHasRight"
                       :open="openNodes"
                       :active="activeNode"
+                      :load-children="loadDestinationChildren"
                       hoverable
                       dense
                       :return-object="true"

--- a/packages/ui/helpers/mixins/mixin-destination-tree.js
+++ b/packages/ui/helpers/mixins/mixin-destination-tree.js
@@ -6,7 +6,7 @@
  * - Handling destination selection
  */
 import { mapState } from 'vuex';
-import { FOLDER } from '~/store/folder';
+import { FOLDER, FETCH_FOLDER_CHILDREN } from '~/store/folder';
 import { findNestedLocation } from '~/utils/workspaces';
 
 export default {
@@ -176,6 +176,34 @@ export default {
       }
 
       return ids;
+    },
+    /**
+     * Lazily fetch a node's direct children on expand.
+     *
+     * The destination tree reuses the sidebar's Vuex state
+     * (`treeviewWorkspacesHasRight`), which is lazy-loaded: a folder with
+     * `hasChildren` is given an empty `children: []` array so Vuetify renders
+     * the expand arrow, but its real children are only fetched when expanded.
+     * Without this handler, folders never expanded in the sidebar appear in the
+     * modal but cannot be opened. We reuse the same store action as the sidebar;
+     * it also persists the children onto the store node so they survive.
+     *
+     * Bind this to `:load-children` on the modal's v-treeview.
+     * @param {Object} item - The tree node being expanded
+     */
+    async loadDestinationChildren(item) {
+      // Vuetify keeps the lazy-load spinner up until this promise settles, so we
+      // must always resolve even on error, otherwise it spins forever.
+      try {
+        const children = await this.$store.dispatch(
+          `${FOLDER}/${FETCH_FOLDER_CHILDREN}`,
+          { node: item }
+        );
+        item.children.splice(0, item.children.length, ...children);
+      } catch (err) {
+        console.error('[destinationTree] failed to load folder children:', err);
+        item.children.splice(0, item.children.length);
+      }
     },
     /**
      * Handle tree selection

--- a/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
@@ -89,6 +89,7 @@ export default {
           :items="treeviewWorkspacesHasRight"
           :open="openNodes"
           :active="activeNode"
+          :load-children="loadDestinationChildren"
           hoverable
           :dense="true"
           :return-object="true"

--- a/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
@@ -111,6 +111,7 @@ export default {
           :items="treeviewWorkspacesHasRight"
           :open="openNodes"
           :active="activeNode"
+          :load-children="loadDestinationChildren"
           hoverable
           :dense="true"
           :return-object="true"


### PR DESCRIPTION
## Problème

Bug remonté : « Si les folders ne sont pas dépliés dans l'arbo en sidebar, alors ils ne sont pas disponibles dans la modale de duplication et on ne peut pas les déplier. »

## Cause racine

L'arbre des workspaces/dossiers est chargé en **lazy-loading**. Un dossier ayant des sous-dossiers (`hasChildren`) reçoit un tableau `children: []` vide — ce qui fait apparaître la flèche d'expansion — mais ses vrais enfants ne sont récupérés (`GET /folders/:id/children`) qu'au moment de l'expansion.

Dans la **sidebar**, ça marche grâce à la prop `load-children` du `v-treeview` qui déclenche le fetch à la volée. Les modales **Copier / Déplacer un email / Dupliquer & traduire** réutilisent le même état Vuex (`treeviewWorkspacesHasRight`) mais leur `v-treeview` **n'avait pas de handler `load-children`**. Résultat : un dossier jamais déplié dans la sidebar apparaît dans la modale mais ne peut pas être ouvert.

## Correction

- Ajout d'une méthode partagée `loadDestinationChildren(item)` dans le mixin `mixin-destination-tree.js`, qui réutilise l'action store existante `FETCH_FOLDER_CHILDREN` (la même que la sidebar, qui persiste aussi les enfants dans le store).
- Branchement via `:load-children="loadDestinationChildren"` sur les trois modales concernées :
  - `mailings-copy-modal.vue` (Copier)
  - `mailings-move-modal.vue` (Déplacer un email)
  - `modal-duplicate-translate.vue` (Dupliquer & traduire)

## Hors périmètre

`folder-move-modal.vue` (déplacer un *dossier*) utilise volontairement `getTreeviewWorkspacesWithoutSubfolders` — il n'affiche que le premier niveau, donc pas de lazy-loading à corriger.

## Test manuel suggéré

1. Ouvrir la modale « Copier » **sans** avoir déplié de dossiers dans la sidebar.
2. Déplier un dossier directement dans la modale → les sous-dossiers doivent maintenant se charger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)