### PR TITLE
fix(modals): répare le build éditeur (min→clamp) et rend les modales de destination responsive

### DIFF
--- a/packages/editor/src/css/badsender-modal.less
+++ b/packages/editor/src/css/badsender-modal.less
@@ -468,9 +468,11 @@
 .bs-modal-overlay {
   // Smart Tree component styling for Adobe modal
   smart-tree {
-    // Grow the trees to fill the tall full-width Adobe modal so users can see
-    // many folders/deliveries at once. Caps at 60vh on short screens.
-    --smart-tree-default-height: min(60vh, 560px);
+    // Grow the trees to fill the tall full-width Adobe modal: target 60vh,
+    // never below 200px (short screens) nor above 560px. clamp() is emitted
+    // as-is by LESS — unlike min(), which LESS evaluates and chokes on for
+    // mixed vh/px units, breaking the editor CSS build.
+    --smart-tree-default-height: clamp(200px, 60vh, 560px);
     border: 1px solid rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }

--- a/packages/ui/components/mailings/modal-duplicate-translate.vue
+++ b/packages/ui/components/mailings/modal-duplicate-translate.vue
@@ -383,7 +383,7 @@ export default {
 </script>
 
 <template>
-  <v-dialog v-model="show" max-width="650" persistent>
+  <v-dialog v-model="show" width="clamp(500px, 60vw, 800px)" persistent>
     <v-card>
       <v-card-title class="d-flex align-center">
         <lucide-languages
@@ -597,7 +597,7 @@ export default {
 
 <style lang="scss" scoped>
 .destination-tree {
-  max-height: 50vh;
+  max-height: clamp(280px, 70vh, 720px);
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/folder-move-modal.vue
+++ b/packages/ui/routes/mailings/__partials/folder-move-modal.vue
@@ -83,7 +83,7 @@ export default {
     ref="moveFolderDialog"
     :title="$t('global.moveFolderAction')"
     :is-form="true"
-    modal-width="650"
+    modal-width="clamp(500px, 60vw, 800px)"
     class="modal-confirm-move-mail"
     @click-outside="close"
   >
@@ -164,7 +164,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so all
    destination-picker actions share the visual pattern. */
 .destination-tree {
-  max-height: 50vh;
+  max-height: clamp(280px, 70vh, 720px);
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-copy-modal.vue
@@ -61,7 +61,7 @@ export default {
     ref="copyMailDialog"
     :title="$t('global.copyMail')"
     :is-form="true"
-    modal-width="650"
+    modal-width="clamp(500px, 60vw, 800px)"
     class="modal-confirm-copy-mail"
     @click-outside="close"
   >
@@ -143,7 +143,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so all
    destination-picker actions share the visual pattern. */
 .destination-tree {
-  max-height: 50vh;
+  max-height: clamp(280px, 70vh, 720px);
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;

--- a/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
+++ b/packages/ui/routes/mailings/__partials/mailings-move-modal.vue
@@ -83,7 +83,7 @@ export default {
     ref="moveMailDialog"
     :title="moveLabelButton"
     :is-form="true"
-    modal-width="650"
+    modal-width="clamp(500px, 60vw, 800px)"
     class="modal-confirm-move-mail"
     @click-outside="close"
   >
@@ -165,7 +165,7 @@ export default {
 /* Same destination-tree shell as the Dupliquer & traduire modal so both
    actions share the visual pattern. */
 .destination-tree {
-  max-height: 50vh;
+  max-height: clamp(280px, 70vh, 720px);
   overflow-y: auto;
   border: 1px solid #e0e0e0;
   border-radius: 4px;


### PR DESCRIPTION
## Contexte

L'agrandissement des modales (`feat/enlarge-tree-modals`, déjà dans staging) cassait l'éditeur d'emails et utilisait des tailles fixes peu responsive. Cette PR corrige les deux.

## 1. Répare le build CSS de l'éditeur (`min()` → `clamp()`)

Les smart-trees de la modale Adobe utilisaient `--smart-tree-default-height: min(60vh, 560px)` dans `badsender-modal.less`. **LESS 3.x interprète `min()` comme sa propre fonction** et échoue sur les unités mixtes vh/px (`error evaluating function min: incompatible types`). Comme `badsender-editor.less` importe ce fichier, **toute la compilation CSS de l'éditeur plantait** → éditeur sans styles.

`clamp(200px, 60vh, 560px)` est laissé tel quel par LESS (pas de fonction `clamp()` interne), donc émis en CSS natif sans aucun échappement — pas de contournement type `~""`.

## 2. Taille responsive des 4 modales de destination

Copier / Déplacer un email / Déplacer un dossier / Dupliquer & traduire :
- **Largeur** : `650px` fixe → `clamp(500px, 60vw, 800px)`
- **Hauteur d'arbre** : `50vh` (sans bornes) → `clamp(280px, 70vh, 720px)`

Même logique relative-à-l'écran que les smart-trees Adobe : on cible une fraction du viewport tout en bornant (plancher pour rester lisible sur petit écran, plafond pour ne pas être démesuré). La hauteur vise 70vh, ce qui laisse de la marge sous le plafond Vuetify de `<v-dialog>` (max-height 90%).

Vuetify passe `clamp()` tel quel à `width` (`convertToUnit` ne touche pas les strings non-numériques).

## Notes

- À noter : `max-height` est un **plafond**, pas une hauteur fixe — avec peu de dossiers l'arbre reste à sa taille naturelle (comportement voulu). La hauteur 70vh se voit sur un workspace bien fourni.
- Pas de changement de comportement fonctionnel, uniquement du CSS/dimensionnement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)