### PR TITLE
refactor(gallery): corrections retours review PR #1055 (US-04)

### DIFF
--- a/cypress/integration/editor/gallery-infra.spec.js
+++ b/cypress/integration/editor/gallery-infra.spec.js
@@ -5,14 +5,28 @@
 // Prerequisites: server running + CYPRESS_MAILING_ID env variable defined.
 
 describe('US-04 — Vue gallery infrastructure: Mosaico non-regression', () => {
+  // Captures console.error calls emitted while the editor window loads, so the
+  // "no critical console errors" test asserts on something real.
+  let consoleErrorSpy;
+
   before(() => {
     cy.login();
+    // Register the spy before openEditor() triggers the editor page load.
+    cy.on('window:before:load', (win) => {
+      consoleErrorSpy = cy.spy(win.console, 'error');
+    });
     cy.openEditor();
   });
 
   describe('Editor loading', () => {
     it('loads without critical console errors', () => {
       cy.get('#page').should('exist');
+      cy.then(() => {
+        expect(
+          consoleErrorSpy,
+          'console.error during editor load'
+        ).to.have.callCount(0);
+      });
     });
 
     it('mounts the Vue #gallery-panel mount point', () => {

--- a/packages/editor/src/css/gallery-vue-panel.less
+++ b/packages/editor/src/css/gallery-vue-panel.less
@@ -1,9 +1,10 @@
 // Vue gallery panel — scoped styles (US-04+)
-// Palette: navy #0d3b4f / cyan #1bb5d6 / cyan-soft #e6f7fb / neutral grey #f5f5f5
+// Palette: aliased from the design-system tokens (style_variables.less),
+// in scope because this file is imported from badsender-editor.less.
 
-@gallery-navy: #0d3b4f;
-@gallery-cyan: #1bb5d6;
-@gallery-cyan-soft: #e6f7fb;
+@gallery-navy: @bs-primary-color;
+@gallery-cyan: @bs-accent-color;
+@gallery-cyan-soft: tint(@bs-accent-color, 90%);
 @gallery-grey: #f5f5f5;
 @gallery-text: #333;
 

--- a/packages/editor/src/js/vue/galleryPlugin.js
+++ b/packages/editor/src/js/vue/galleryPlugin.js
@@ -4,7 +4,13 @@ const Vue = require('vue/dist/vue.common');
 const { galleryBridge } = require('../ext/badsender-gallery-bridge');
 
 module.exports = {
-  viewModel(vm, ko) {},
+  viewModel(vm, ko) {
+    // Expose the bridge to Knockout (mirrors badsender-events-hub's
+    // `vm.bsEventsHub`) so KO-side code can dispatch GALLERY_REFRESH and
+    // listen to GALLERY_IMAGE_SELECTED. Without this the Vue→KO methods
+    // would be unreachable from the Mosaico viewModel.
+    vm.galleryBridge = galleryBridge;
+  },
   init(vm) {
     Vue.component('GalleryPanelPlugin', {
       data: () => ({

--- a/packages/server/scripts/migrate-gallery-v1.js
+++ b/packages/server/scripts/migrate-gallery-v1.js
@@ -15,7 +15,6 @@ const mongoose = require('mongoose');
 const config = require('../node.config.js');
 const { Galleries } = require('../common/models.common.js');
 
-const BATCH_SIZE = 10;
 const isDryRun = process.argv.includes('--dry-run');
 
 // ---------------------------------------------------------------------------
@@ -78,66 +77,48 @@ async function run() {
   }
 
   const totalGalleries = await Galleries.countDocuments();
-  const allGalleriesLean = await Galleries.find({}, 'files').lean();
-  const totalImages = allGalleriesLean.reduce(
-    (sum, g) => sum + g.files.length,
-    0
-  );
 
   console.log('Migration galerie V1');
-  console.log(
-    `Galeries : ${totalGalleries} | Images totales : ${totalImages}\n`
-  );
+  console.log(`Galeries : ${totalGalleries}\n`);
 
   let galleryCount = 0;
   let totalMigrated = 0;
   let totalSkipped = 0;
   let totalErrors = 0;
 
+  // Stream galleries one by one — the cursor keeps memory flat even on a
+  // large collection. Each gallery is saved sequentially, so there is no
+  // throughput gain in buffering a batch.
   const cursor = Galleries.find({}).cursor();
-  let batch = [];
-
-  const processBatch = async (galleries) => {
-    for (const gallery of galleries) {
-      galleryCount++;
-      const galleryId = String(gallery.creationOrWireframeId);
-
-      try {
-        const { migrated, skipped } = await migrateGallery(gallery, isDryRun);
-        totalMigrated += migrated;
-        totalSkipped += skipped;
-
-        console.log(
-          `[${galleryCount}/${totalGalleries}] ${galleryId} — ` +
-            `${migrated} migrée(s), ${skipped} déjà à jour`
-        );
-      } catch (err) {
-        totalErrors++;
-        console.error(
-          `[${galleryCount}/${totalGalleries}] ${galleryId} — ERREUR : ${err.message}`
-        );
-      }
-    }
-  };
 
   for (
     let gallery = await cursor.next();
     gallery !== null;
     gallery = await cursor.next()
   ) {
-    batch.push(gallery);
-    if (batch.length >= BATCH_SIZE) {
-      await processBatch(batch);
-      batch = [];
-    }
-  }
+    galleryCount++;
+    const galleryId = String(gallery.creationOrWireframeId);
 
-  if (batch.length > 0) {
-    await processBatch(batch);
+    try {
+      const { migrated, skipped } = await migrateGallery(gallery, isDryRun);
+      totalMigrated += migrated;
+      totalSkipped += skipped;
+
+      console.log(
+        `[${galleryCount}/${totalGalleries}] ${galleryId} — ` +
+          `${migrated} migrée(s), ${skipped} déjà à jour`
+      );
+    } catch (err) {
+      totalErrors++;
+      console.error(
+        `[${galleryCount}/${totalGalleries}] ${galleryId} — ERREUR : ${err.message}`
+      );
+    }
   }
 
   console.log('\n--- Résultat ---');
   console.log(`Galeries traitées : ${galleryCount}/${totalGalleries}`);
+  console.log(`Images totales    : ${totalMigrated + totalSkipped}`);
   console.log(`Images migrées    : ${totalMigrated}`);
   console.log(`Images skippées   : ${totalSkipped}`);
   if (totalErrors > 0) {


### PR DESCRIPTION
Corrige les retours de review sur la PR #1055 (infrastructure US-04 du panneau galerie Vue).

## Changements

- **`gallery-vue-panel.less`** — les couleurs ne sont plus des hex codés en dur hors design-system. Alias vers les tokens du DS : `@gallery-navy: @bs-primary-color`, `@gallery-cyan: @bs-accent-color`, `@gallery-cyan-soft: tint(@bs-accent-color, 90%)`. (`@bs-*` est en scope via `style_mosaico.less` → `style_variables.less`.)
- **`migrate-gallery-v1.js`** — suppression du `BATCH_SIZE` (aucun gain : les `save()` étaient déjà séquentiels) et du scan `.lean()` global qui chargeait toute la collection en RAM juste pour un `console.log` (risque OOM). Le total d'images est désormais accumulé pendant le passage du curseur.
- **`galleryPlugin.js`** — expose `vm.galleryBridge = galleryBridge` dans la passe `viewModel` (mire `vm.bsEventsHub`), pour que `refresh()`/`selectImage()` soient atteignables depuis Knockout (sinon code mort).
- **`gallery-infra.spec.js`** — le test « loads without critical console errors » assertait seulement la présence de `#page` ; ajout d'un spy `console.error` enregistré sur `window:before:load`.

## Tests
- `yarn build` + `yarn test-ci` à valider (gates CI). Pas de `node_modules` dans le workspace de dev, donc non exécutés localement ; syntaxe JS vérifiée via `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)