### PR TITLE
fix(mailing): éviter une unhandled rejection au load de mail.service

### DIFF
--- a/packages/server/mailing/mail.service.js
+++ b/packages/server/mailing/mail.service.js
@@ -16,7 +16,18 @@ if (mailConfig.service) {
 }
 const transporter = nodemailer.createTransport(config.emailTransport);
 
-const mailReady = transporter.verify();
+// Verify the SMTP connection at startup. `mailReady` is exposed so callers can
+// await readiness. Skipped under test: it does a real network round-trip on
+// every module import, and its async rejection (bad/absent SMTP creds) would
+// otherwise surface as an unhandled rejection that Jest mis-attributes to an
+// unrelated test. A catch is attached so a startup failure (e.g. in dev/CI)
+// stays a logged warning rather than crashing the process.
+const mailReady =
+  config.NODE_ENV === 'test' ? Promise.resolve() : transporter.verify();
+mailReady.catch(function (err) {
+  console.log(chalk.red('smtp verification failed'));
+  console.log(err.message);
+});
 
 function send(options) {
   const mailOptions = extend({}, options, pick(config.emailOptions, ['from']));


### PR DESCRIPTION
## Problème

Faux échec flaky de `tests/server/security/exploit-f1-ssrf-apihost.test.js` avec l'erreur `Invalid login: 535 5.7.8 Authentication failed` — sans rapport avec ce que le test vérifie. Lancé seul, le test passe.

## Cause racine

`packages/server/mailing/mail.service.js` appelait `transporter.verify()` au **chargement du module**, sans `.catch()` :

```js
const mailReady = transporter.verify();
```

Plusieurs tests importent transitivement la chaîne mailing. À l'import, `verify()` lance une vraie authentification SMTP qui échoue en env de test (pas de creds valides). La rejection non gérée était attribuée par Jest **au test en cours d'exécution à ce moment-là** — de façon non déterministe, le test SSRF.

## Fix

- `verify()` ignoré sous `NODE_ENV=test` (évite aussi un appel réseau réel inutile à chaque import)
- `.catch()` ajouté pour qu'un échec de vérification en dev/CI reste un warning loggé plutôt qu'une unhandled rejection

## Vérification

Suite serveur complète (484 tests) verte 3× de suite, sans erreur SMTP ni log parasite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)