### PR TITLE
fix(tracking): respecter le choix verrouillé multi-valeurs + ignorer les UTM GA fantômes

### DIFF
--- a/packages/editor/src/js/vue/trackingParamsPlugin.js
+++ b/packages/editor/src/js/vue/trackingParamsPlugin.js
@@ -126,7 +126,18 @@ module.exports = {
       mounted() {
         this.hasGoogleAnalyticsUtmSubscription = vm.content().tracking().hasGoogleAnalyticsUtm.subscribe(this.updateHasGoogleAnalyticsUtm);
         this.trackingUrlsSubscription = vm.content().tracking().trackingUrls.subscribe(this.updateTrackingUrls);
-        if (this.isManaged) this.ensureManagedRows();
+        if (this.isManaged) {
+          // The Google-Analytics UTM helper fields are only editable in legacy
+          // (non-managed) mode. If a mailing carries a stale hasGoogleAnalyticsUtm
+          // flag from before the group enabled managed tracking, those values are
+          // invisible here but would otherwise leak into the export. Clear the
+          // flag so the persisted state matches what the editor shows.
+          if (this.hasGoogleAnalyticsUtm) {
+            this.hasGoogleAnalyticsUtm = false;
+            vm.content().tracking().hasGoogleAnalyticsUtm(false);
+          }
+          this.ensureManagedRows();
+        }
       },
       beforeDestroy() {
         this.hasGoogleAnalyticsUtmSubscription.dispose();

--- a/packages/server/utils/download-zip-markdown.js
+++ b/packages/server/utils/download-zip-markdown.js
@@ -135,7 +135,12 @@ const buildTrackingContext = (groupTrackingConfig) => {
  * For a managed key, decide which value to actually inject.
  *
  * The `values` list is only a CONSTRAINT when the admin made it one:
- *   - `lockedValues`        → the value is imposed, force the configured one.
+ *   - `lockedValues` + a SINGLE allowed value → the value is fully imposed,
+ *     force it (the editor shows a read-only input).
+ *   - `lockedValues` + MULTIPLE allowed values → the user PICKS one from the
+ *     list (the editor shows a strict combobox); keep that choice as long as
+ *     it belongs to the list, otherwise fall back to the first allowed value
+ *     so a locked param is never left empty/forged.
  *   - `restrictValues` (group-global) → the value must belong to the list.
  * Otherwise `values` is just a SUGGESTION list and any value (including a
  * custom one typed by the user) is accepted. This mirrors the editor UX:
@@ -146,7 +151,10 @@ const buildTrackingContext = (groupTrackingConfig) => {
 const resolveManagedValue = (param, value, restrictValues) => {
   const allowed = Array.isArray(param.values) ? param.values : [];
   if (param.lockedValues) {
-    return allowed.length > 0 ? allowed[0] : value;
+    if (allowed.length === 0) return value;
+    // Single locked value → imposed. Multiple → honor the user's in-list
+    // choice, else fall back to the first allowed value.
+    return allowed.includes(value) ? value : allowed[0];
   }
   if (restrictValues && allowed.length > 0) {
     return allowed.includes(value) ? value : null;
@@ -234,7 +242,14 @@ const getUrlWithTrackingParams = (
     }
   }
 
-  if (tracking && tracking.hasGoogleAnalyticsUtm) {
+  // The Google-Analytics UTM helper fields only exist in the LEGACY (no group
+  // config) editor mode. Once a group enables managed tracking, those fields
+  // are no longer rendered, so any value still persisted on the mailing from a
+  // pre-config state is a "ghost": invisible in the editor but otherwise
+  // re-injected here (even overriding a managed value, same key → last wins).
+  // Skip them entirely in managed mode so the export mirrors the editor.
+  const isManaged = managedParams.size > 0;
+  if (!isManaged && tracking && tracking.hasGoogleAnalyticsUtm) {
     handlePair(tracking.utmSourceKey, tracking.utmSourceValue);
     handlePair(tracking.utmMediumKey, tracking.utmMediumValue);
     handlePair(tracking.utmCampaignKey, tracking.utmCampaignValue);

--- a/packages/server/utils/resolve-tracking-config.js
+++ b/packages/server/utils/resolve-tracking-config.js
@@ -101,7 +101,8 @@ function validateRequiredTrackingParams(tracking, resolvedConfig) {
   return requiredParams
     .filter((p) => {
       const allowed = Array.isArray(p.values) ? p.values : [];
-      // Locked params are always satisfied: injection forces values[0].
+      // Locked params are always satisfied: injection keeps the user's in-list
+      // choice, or falls back to values[0] — never empty.
       if (p.lockedValues && allowed.length > 0) return false;
       const value = valueByKey.get(p.key);
       if (!value) return true;

--- a/tests/server/tracking/get-url-with-tracking-params.test.js
+++ b/tests/server/tracking/get-url-with-tracking-params.test.js
@@ -223,7 +223,10 @@ describe('getUrlWithTrackingParams', () => {
       expect(out).toBe('https://x.com?utm_source=newsletter');
     });
 
-    it('drops UTM fields not in the whitelist when restrictValues is on', () => {
+    it('ignores the GA UTM fields entirely in managed mode (not rendered in the editor)', () => {
+      // groupConfig.params is non-empty → managed mode. The GA UTM helper
+      // fields have no editor UI there, so they must not be injected even when
+      // a key matches a managed key.
       const out = getUrlWithTrackingParams(
         'https://x.com',
         {
@@ -235,7 +238,7 @@ describe('getUrlWithTrackingParams', () => {
         },
         groupConfig
       );
-      expect(out).toBe('https://x.com?utm_source=news');
+      expect(out).toBe('https://x.com');
     });
   });
 
@@ -336,6 +339,88 @@ describe('getUrlWithTrackingParams', () => {
         }
       );
       expect(out).toBe('https://x.com?utm_source=official');
+    });
+
+    it('keeps the user-picked value for a locked param with multiple allowed values', () => {
+      // Locked + multiple values is a strict combobox in the editor: the user
+      // PICKS from the list. The chosen in-list value must survive export
+      // (regression: it used to be overwritten by the first allowed value).
+      const out = getUrlWithTrackingParams(
+        'https://x.com',
+        { trackingUrls: [{ key: 'utm_source', value: 'adobe' }] },
+        {
+          enabled: true,
+          params: [
+            {
+              key: 'utm_source',
+              values: ['newsletter', 'adobe', 'trigger'],
+              lockedValues: true,
+            },
+          ],
+        }
+      );
+      expect(out).toBe('https://x.com?utm_source=adobe');
+    });
+
+    it('falls back to the first allowed value when a locked multi-value pick is out of list', () => {
+      const out = getUrlWithTrackingParams(
+        'https://x.com',
+        { trackingUrls: [{ key: 'utm_source', value: 'forged' }] },
+        {
+          enabled: true,
+          params: [
+            {
+              key: 'utm_source',
+              values: ['newsletter', 'adobe', 'trigger'],
+              lockedValues: true,
+            },
+          ],
+        }
+      );
+      expect(out).toBe('https://x.com?utm_source=newsletter');
+    });
+
+    it('ignores stale Google-Analytics UTM fields in managed mode (ghost values)', () => {
+      // The GA UTM helper fields are only editable in legacy mode. In managed
+      // mode they are invisible in the editor and must not leak into export,
+      // even when a value lingers from a pre-config state.
+      const out = getUrlWithTrackingParams(
+        'https://x.com',
+        {
+          trackingUrls: [{ key: 'utm_source', value: 'adobe' }],
+          hasGoogleAnalyticsUtm: true,
+          utmSourceKey: 'utm_source',
+          utmSourceValue: 'ghost',
+          utmMediumKey: 'utm_medium',
+          utmMediumValue: 'ghost_medium',
+        },
+        {
+          enabled: true,
+          params: [
+            {
+              key: 'utm_source',
+              values: ['newsletter', 'adobe'],
+              lockedValues: true,
+            },
+          ],
+        }
+      );
+      // utm_source keeps the managed pick (not the GA ghost), and the GA-only
+      // utm_medium is dropped entirely.
+      expect(out).toBe('https://x.com?utm_source=adobe');
+    });
+
+    it('still applies Google-Analytics UTM fields in legacy mode (no group config)', () => {
+      const out = getUrlWithTrackingParams(
+        'https://x.com',
+        {
+          hasGoogleAnalyticsUtm: true,
+          utmSourceKey: 'utm_source',
+          utmSourceValue: 'news',
+        },
+        { enabled: false, params: [] }
+      );
+      expect(out).toBe('https://x.com?utm_source=news');
     });
 
     it('accepts a custom value when the list is a suggestion (not locked, not restricted)', () => {


### PR DESCRIPTION
## Contexte

Un client a remonté quatre comportements de tracking UTM dont trois bogués. La cause profonde est un **désaccord entre l'éditeur et l'export** : l'éditeur affiche/masque certains champs selon le mode (legacy vs managé), mais l'export ne tenait pas compte de ces règles.

| Cas client | Avant | Après |
|---|---|---|
| Paramétrage libre | ✅ | ✅ (inchangé) |
| Imposé non oblig. non verrouillé | 🔴 valeurs libres fantômes à l'export | ✅ |
| Imposé non verrouillé | 🔴 valeurs libres fantômes à l'export | ✅ |
| Imposé (verrouillé) | 🔴 1ère valeur passée systématiquement | ✅ |

## Bug A — paramètre verrouillé multi-valeurs

Quand un paramètre est verrouillé **avec plusieurs valeurs autorisées** (ex. `utm_source = newsletter, adobe, trigger…`), l'éditeur affiche un combobox strict où l'utilisateur **choisit** une valeur. Mais à l'export, `resolveManagedValue` renvoyait toujours `allowed[0]` et jetait ce choix.

**Correctif** : on honore désormais la valeur choisie tant qu'elle appartient à la liste, avec fallback sur la première valeur si elle est vide/hors liste. Le cas verrouillé **mono-valeur** (valeur entièrement imposée) reste inchangé.

## Bug B — UTM Google Analytics fantômes

Les champs UTM Google Analytics (`hasGoogleAnalyticsUtm`, `utmSourceValue`…) ne sont éditables qu'en **mode legacy**. Quand un groupe active une config managée, ces champs disparaissent de l'éditeur **mais leurs valeurs restent en base** et étaient réinjectées à l'export — écrasant même une valeur managée (même clé → dernier gagnant). D'où des « valeurs libres à l'export absentes de l'interface ».

**Correctif** :
- l'export ignore les UTM GA en **mode managé** ;
- l'éditeur éteint le flag `hasGoogleAnalyticsUtm` au montage pour aligner l'état persisté sur l'affichage.

## Implication à valider (revue produit)

Le nettoyage du flag GA en mode managé **persiste automatiquement** dès l'ouverture du mailing, sans notification. Les valeurs `utmSourceValue`/etc. ne sont pas effacées (seul le flag est éteint), donc réversible si le groupe désactivait sa config. À confirmer que cette mutation silencieuse convient — sinon on peut s'appuyer uniquement sur le filtre côté export.

## Tests

- 73 tests tracking passent (`yarn jest tests/server/tracking/`).
- Nouveaux cas : choix verrouillé multi-valeurs respecté, fallback hors liste, UTM GA ignorés en managé, UTM GA toujours actifs en legacy.
- 1 test existant mis à jour pour refléter le nouveau contrat (UTM GA non injectés en mode managé) — changement délibéré.

🤖 Generated with [Claude Code](https://claude.com/claude-code)