### PR TITLE
fix(tracking): ne préremplir que les params locked+required à valeur unique

### DIFF
--- a/packages/editor/src/js/vue/trackingParamsPlugin.js
+++ b/packages/editor/src/js/vue/trackingParamsPlugin.js
@@ -160,13 +160,19 @@ module.exports = {
             // Falling back to false otherwise keeps the editor behavior sane for
             // legacy configs that pre-date the flag.
             const lockedValues = !!param.lockedValues && values.length > 0;
+            const required = !!param.required;
             return {
               key: param.key,
               values,
-              required: !!param.required,
+              required,
               lockedValues,
+              // A single allowed value is imposed (read-only, pre-filled) only
+              // when it is BOTH locked and required. Otherwise the user must
+              // pick it explicitly via the locked combobox (kept empty by
+              // default), per the product rule "required = empty by default".
+              forcedSingle: lockedValues && required && values.length === 1,
               value: existing ? existing.value || '' : '',
-              missing: !!param.required && !(existing && existing.value),
+              missing: required && !(existing && existing.value),
             };
           });
         },
@@ -273,29 +279,30 @@ module.exports = {
             const idx = current.findIndex((tu) => tu && tu.key === param.key);
             const values = Array.isArray(param.values) ? param.values : [];
             const lockedValues = !!param.lockedValues && values.length > 0;
-            // Determine the value to pre-fill so the row is never left empty
-            // when a value is effectively imposed/suggested:
-            //   - locked: the value is imposed by the admin → always force it
-            //     (values[0]). It must not depend on the user focusing the
-            //     field, otherwise a required+locked param stays "missing".
-            //   - unlocked with a single allowed value → suggest it (editable).
-            // Anything else (multiple unlocked values, no value) stays empty
-            // so the user actively picks/types.
-            let prefill = '';
-            if (lockedValues) prefill = values[0];
-            else if (values.length === 1) prefill = values[0];
+            const required = !!param.required;
+            // Pre-filling only happens when a value is BOTH imposed and
+            // mandatory with no real choice to make, i.e. locked + required
+            // + a single allowed value. In that and only that case the value
+            // (values[0]) is forced.
+            //
+            // Every other case must stay EMPTY by default so the user takes
+            // an explicit action:
+            //   - required (any flavour) means "the user must pick/type" →
+            //     never silently fill it.
+            //   - non-required, single value → leave empty (it is optional).
+            //   - locked multi-value → the user picks among the locked values.
+            const forcedSingle =
+              lockedValues && required && values.length === 1;
+            const prefill = forcedSingle ? values[0] : '';
             if (idx === -1) {
               current.push({ key: param.key, value: prefill });
               mutated = true;
-            } else if (lockedValues && current[idx].value !== values[0]) {
-              // Locked value must always reflect the admin-imposed value,
+            } else if (forcedSingle && current[idx].value !== values[0]) {
+              // The imposed single value must always reflect the admin value,
               // overriding any stale/forged value already present.
               current[idx] = Object.assign({}, current[idx], {
                 value: values[0],
               });
-              mutated = true;
-            } else if (prefill && !current[idx].value) {
-              current[idx] = Object.assign({}, current[idx], { value: prefill });
               mutated = true;
             }
           });
@@ -400,25 +407,26 @@ module.exports = {
                 </div>
                 <span class="tracking-equals">=</span>
                 <div class="propInput tracking-input">
-                  <!-- Locked + multiple values: same combobox in strict mode
-                       (input read-only) so the dropdown look matches the
-                       unlocked case. -->
+                  <!-- Locked + single value + required: the value is imposed,
+                       pre-filled by ensureManagedRows. Read-only display. -->
+                  <input
+                    v-if="row.forcedSingle"
+                    type="text"
+                    :value="row.value"
+                    readonly
+                  />
+                  <!-- Any other locked case (multi-value, or single value but
+                       not required): strict combobox so the user picks among
+                       the locked value(s). Empty by default; nothing is forced
+                       so an optional locked param can legitimately stay empty. -->
                   <tracking-combobox
-                    v-if="row.lockedValues && row.values.length > 1"
+                    v-else-if="row.lockedValues"
                     strict
                     :value="row.value"
                     :options="row.values"
                     placeholder="value"
                     @input="(val) => setManagedValue(row.key, val)"
                   ></tracking-combobox>
-                  <!-- Locked + single value: read-only, value forced -->
-                  <input
-                    v-else-if="row.lockedValues && row.values.length === 1"
-                    type="text"
-                    :value="row.values[0]"
-                    readonly
-                    @focus="setManagedValue(row.key, row.values[0])"
-                  />
                   <!-- Unlocked + multiple values: combobox (chevron opens
                        the suggestion list; the input value stays editable). -->
                   <tracking-combobox
@@ -428,9 +436,9 @@ module.exports = {
                     placeholder="value"
                     @input="(val) => setManagedValue(row.key, val)"
                   ></tracking-combobox>
-                  <!-- Unlocked + 1 value (or no values): plain editable input.
-                       Single-value case is pre-filled by ensureManagedRows; no
-                       chevron needed because there is nothing to choose from. -->
+                  <!-- Unlocked + 1 value (or no values): plain editable input,
+                       empty by default (the single value is only a suggestion,
+                       not imposed); no chevron since there is nothing to pick. -->
                   <input
                     v-else
                     type="text"

--- a/packages/server/utils/download-zip-markdown.js
+++ b/packages/server/utils/download-zip-markdown.js
@@ -138,9 +138,10 @@ const buildTrackingContext = (groupTrackingConfig) => {
  *   - `lockedValues` + a SINGLE allowed value → the value is fully imposed,
  *     force it (the editor shows a read-only input).
  *   - `lockedValues` + MULTIPLE allowed values → the user PICKS one from the
- *     list (the editor shows a strict combobox); keep that choice as long as
- *     it belongs to the list, otherwise fall back to the first allowed value
- *     so a locked param is never left empty/forged.
+ *     list (the editor shows a strict combobox, empty by default); keep that
+ *     choice if it belongs to the list, otherwise DROP the pair (null). We do
+ *     not force values[0]: a required param without a choice is rejected
+ *     upstream, and an optional one must stay empty.
  *   - `restrictValues` (group-global) → the value must belong to the list.
  * Otherwise `values` is just a SUGGESTION list and any value (including a
  * custom one typed by the user) is accepted. This mirrors the editor UX:
@@ -152,9 +153,15 @@ const resolveManagedValue = (param, value, restrictValues) => {
   const allowed = Array.isArray(param.values) ? param.values : [];
   if (param.lockedValues) {
     if (allowed.length === 0) return value;
-    // Single locked value → imposed. Multiple → honor the user's in-list
-    // choice, else fall back to the first allowed value.
-    return allowed.includes(value) ? value : allowed[0];
+    // Single locked value → imposed: always inject it (the editor shows it as
+    // a read-only field, and a required one is auto-filled).
+    if (allowed.length === 1) return allowed[0];
+    // Multiple locked values → the user PICKS one. Inject that choice only if
+    // it belongs to the list. An empty or out-of-list value is dropped (null)
+    // rather than silently forced to values[0]: a required param is caught
+    // upstream by validateRequiredTrackingParams, and an optional one must
+    // stay empty when the user did not choose.
+    return allowed.includes(value) ? value : null;
   }
   if (restrictValues && allowed.length > 0) {
     return allowed.includes(value) ? value : null;

--- a/packages/server/utils/resolve-tracking-config.js
+++ b/packages/server/utils/resolve-tracking-config.js
@@ -101,10 +101,17 @@ function validateRequiredTrackingParams(tracking, resolvedConfig) {
   return requiredParams
     .filter((p) => {
       const allowed = Array.isArray(p.values) ? p.values : [];
-      // Locked params are always satisfied: injection keeps the user's in-list
-      // choice, or falls back to values[0] — never empty.
-      if (p.lockedValues && allowed.length > 0) return false;
       const value = valueByKey.get(p.key);
+      // Locked param with a SINGLE allowed value → imposed and auto-filled by
+      // the editor (read-only). It is always satisfied.
+      if (p.lockedValues && allowed.length === 1) return false;
+      // Locked param with MULTIPLE allowed values → the user must actively pick
+      // one from the list (it is empty by default). Missing if no in-list value
+      // was chosen. We do NOT silently fall back to values[0] anymore, so that
+      // "required" keeps its meaning: an explicit choice is mandatory.
+      if (p.lockedValues && allowed.length > 1) {
+        return !value || !allowed.includes(value);
+      }
       if (!value) return true;
       // Under restrictValues, only an allowed value survives injection.
       if (restrictValues && allowed.length > 0 && !allowed.includes(value)) {

--- a/tests/server/tracking/get-url-with-tracking-params.test.js
+++ b/tests/server/tracking/get-url-with-tracking-params.test.js
@@ -362,7 +362,11 @@ describe('getUrlWithTrackingParams', () => {
       expect(out).toBe('https://x.com?utm_source=adobe');
     });
 
-    it('falls back to the first allowed value when a locked multi-value pick is out of list', () => {
+    it('drops a locked multi-value param when the picked value is out of list', () => {
+      // The user must PICK an in-list value (the editor shows a strict combobox,
+      // empty by default). An out-of-list/forged value is NOT silently coerced
+      // to the first allowed value: it is dropped. A required param left without
+      // a valid choice is caught upstream by validateRequiredTrackingParams.
       const out = getUrlWithTrackingParams(
         'https://x.com',
         { trackingUrls: [{ key: 'utm_source', value: 'forged' }] },
@@ -377,7 +381,7 @@ describe('getUrlWithTrackingParams', () => {
           ],
         }
       );
-      expect(out).toBe('https://x.com?utm_source=newsletter');
+      expect(out).toBe('https://x.com');
     });
 
     it('ignores stale Google-Analytics UTM fields in managed mode (ghost values)', () => {

--- a/tests/server/tracking/resolve-tracking-config.test.js
+++ b/tests/server/tracking/resolve-tracking-config.test.js
@@ -290,6 +290,41 @@ describe('validateRequiredTrackingParams', () => {
     expect(validateRequiredTrackingParams({}, lockedCfg)).toEqual([]);
   });
 
+  // Locked + required + MULTIPLE allowed values: the user must actively pick
+  // one (strict combobox, empty by default). It is no longer auto-filled, so
+  // an empty or out-of-list value must be flagged as missing.
+  it('flags a locked required multi-value param when nothing is picked', () => {
+    const lockedMultiCfg = {
+      enabled: true,
+      params: [
+        {
+          key: 'utm_source',
+          required: true,
+          lockedValues: true,
+          values: ['newsletter', 'adobe'],
+        },
+      ],
+    };
+    // no value chosen → missing
+    expect(validateRequiredTrackingParams({}, lockedMultiCfg)).toEqual([
+      'utm_source',
+    ]);
+    // out-of-list value → still missing (it is dropped at injection)
+    expect(
+      validateRequiredTrackingParams(
+        { trackingUrls: [{ key: 'utm_source', value: 'forged' }] },
+        lockedMultiCfg
+      )
+    ).toEqual(['utm_source']);
+    // an in-list pick satisfies it
+    expect(
+      validateRequiredTrackingParams(
+        { trackingUrls: [{ key: 'utm_source', value: 'adobe' }] },
+        lockedMultiCfg
+      )
+    ).toEqual([]);
+  });
+
   it('flags a required param whose value is out of the allowed list under restrictValues', () => {
     const restrictedCfg = {
       enabled: true,


### PR DESCRIPTION
## Contexte

Sur une nouvelle créa, le `select` des paramètres de tracking managés préchargeait automatiquement la première valeur dès qu'une seule valeur était possible — **sans tenir compte de `required`**. Or `required` signifie « champ vide par défaut, l'utilisateur doit faire une action ».

## Règle appliquée (rappel PO)

- `locked` = je ne peux pas saisir librement la valeur (contrainte/imposée)
- `required` = je suis obligé de choisir → **champ vide par défaut**
- **Préremplissage UNIQUEMENT si `locked && required && une seule valeur possible`**

| locked | required | nb valeurs | comportement |
|--------|----------|-----------|--------------|
| ✓ | ✓ | 1 | **prérempli** (imposé, input read-only) |
| ✓ | ✓ | plusieurs | vide → combobox stricte, l'user choisit |
| ✓ | ✗ | 1 | vide → combobox stricte (1 option), opt-in |
| ✓ | ✗ | plusieurs | vide → combobox stricte |
| ✗ | * | 1 | vide (la valeur n'est qu'une suggestion) |
| ✗ | * | plusieurs | vide |

## Changements

**Éditeur** (`trackingParamsPlugin.js`)
- `ensureManagedRows` : suppression du préremplissage `else if (values.length === 1)`. Introduction de `forcedSingle = locked && required && 1 valeur`, seul cas prérempli.
- Template : input read-only rendu uniquement pour `forcedSingle` ; tous les autres cas `locked` passent par la combobox stricte vide. Suppression du `@focus` qui re-remplissait.

**Serveur** (cohérence de bout en bout, pour que `required` garde son sens)
- `validateRequiredTrackingParams` : un param `locked` multi-valeurs `required` n'est plus considéré satisfait par défaut → bloqué si aucun choix in-list.
- `resolveManagedValue` : ne force plus `values[0]` pour un `locked` multi vide/hors-liste → la paire est droppée (un `required` est bloqué en amont, un optionnel reste vide).

## Tests

- ✅ 506/506 tests jest (40 suites), dont 74 tracking
- 1 test mis à jour (ancien fallback `values[0]`, rejeté par la règle PO)
- 3 nouveaux cas ajoutés (locked+required+multi : vide, hors-liste, in-list)
- ✅ Build éditeur OK (bundle Mosaico)

## Plan de test manuel

Voir le checklist dans le premier commentaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
