### PR TITLE
fix(editor): crayon d'édition d'image inopérant après ajout via drag-drop/galerie

### DIFF
--- a/packages/editor/src/js/viewmodel.js
+++ b/packages/editor/src/js/viewmodel.js
@@ -819,8 +819,36 @@ function initializeEditor(content, blockDefs, thumbPathConverter, galleryUrl) {
  *
  */
   viewModel.editImage = function (src, domElement, vm) {
-    // Locate the corresponding file upload input within the nearest upload zone
-    var $uploadInput = $(domElement).closest('.uploadzone').find('input.fileupload');
+    // Locate the corresponding file upload input within the nearest upload zone.
+    // The image block renders TWO inputs in mutually-exclusive `ko if` branches:
+    //   - `input.fileupload.nofile`  when the block has no image (_src == '')
+    //   - `input.fileupload.withfile` when the block has an image (_src != '')
+    // The pencil only shows when _src != '', so the active, plugin-bound input is
+    // `.withfile`. Targeting the generic `input.fileupload` used to also grab the
+    // `.nofile` input: right after adding an image (drag-drop / gallery finder),
+    // Knockout is mid-swap between the two branches and the jQuery set could
+    // include a disposed/not-yet-initialised input, so `.fileupload('add')`
+    // silently no-op'd — until a page refresh rebuilt the DOM with only
+    // `.withfile` present. Scope to `.withfile` (and take the last, live one) to
+    // always hit the initialised input.
+    var $uploadInput = $(domElement)
+      .closest('.uploadzone')
+      .find('input.fileupload.withfile')
+      .last();
+
+    // Guard: if the active upload input isn't in the DOM / bound to the plugin,
+    // bail loudly instead of the previous silent no-op (which read as "the
+    // pencil does nothing").
+    if (
+      !$uploadInput.length ||
+      typeof $uploadInput.fileupload !== 'function'
+    ) {
+      console.error('editImage: no initialised upload input found');
+      if (vm && vm.notifier && typeof vm.notifier.error === 'function') {
+        vm.notifier.error('Unable to edit this image. Please try again.');
+      }
+      return;
+    }
 
     // Construct the full image URL if it's not already an absolute path
     var sourceValue = src();


### PR DESCRIPTION
## Symptôme

Après avoir ajouté une image à un bloc (glisser-déposer **ou** finder de galerie), le **crayon « Éditer l'image »** ne fait rien. Ça remarche après un **refresh** / réouverture du mail. Reproduit en **staging ET en prod**.

## Cause

Le template du bloc image (`img-wysiwyg.tmpl.html`) rend **deux** `input.fileupload` dans des branches `ko if` mutuellement exclusives, sous le **même** `td.uploadzone` :

- `input.fileupload.nofile` — quand `_src() == ''` (bloc vide)
- `input.fileupload.withfile` — quand `_src() != ''` (bloc avec image)

`editImage` (viewmodel.js) récupérait l'input via le sélecteur **générique** :
```js
$(domElement).closest('.uploadzone').find('input.fileupload')
```
qui peut ramener **les deux** inputs. Juste après l'ajout d'une image, `_src` passe de `''` à une valeur → Knockout est en plein **swap** entre les deux branches : le jQuery set contenait un input **en cours de disposal / pas encore initialisé** par le plugin jQuery-File-Upload, donc `.fileupload('add', …)` faisait un **no-op silencieux**.

Après refresh, le DOM démarre directement avec `_src != ''` → seul `.withfile` existe, proprement lié → le crayon fonctionne. D'où le « OK après refresh ».

Bug **préexistant**, sans lien avec la feature content-feed (`editImage` date de ~15 mois et n'a pas été touché par cette feature).

## Correctif

- Cibler explicitement **`input.fileupload.withfile`** (`.last()`), l'input actif qui coexiste toujours avec le crayon (tous deux gated sur `_src() != ''`).
- **Garde-fou** : si aucun input initialisé n'est trouvé, notifier l'utilisateur au lieu du no-op silencieux (évite qu'une future régression repasse inaperçue).

## Vérification

- Build éditeur (`yarn editor:build`) : **OK**.
- `node --check` sur viewmodel.js : **OK**.
- ⚠️ **Non testé en navigateur** dans cette itération : c'est un bug de timing DOM, à confirmer en conditions réelles (ajouter une image par drag-drop puis cliquer le crayon, sans refresh).

## À tester au review

1. Bloc image vide → glisser-déposer une image → cliquer le crayon **sans refresh** → l'outil d'édition doit s'ouvrir.
2. Idem via le finder de galerie.
3. Non-régression : upload classique (bouton upload) + édition après refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)