### PR TITLE
docs(skills): add git-sync skill to keep branches rebased on their base

### DIFF
--- a/.claude/skills/git-sync/SKILL.md
+++ b/.claude/skills/git-sync/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: git-sync
+description: Keep the current branch rebased on its base branch and the worktree clean. Use at session start, after each commit, before opening or updating a PR, when a rebase conflicts, or when the user says "rebase", "sync", "am I up to date", "merge main".
+---
+
+Rebase is maintenance, not a finishing move. Keep a **short leash**: never more than a few base commits behind, never more than one unit of work in the tree.
+
+## Resolve `<base>` once per session
+
+```bash
+git rev-parse --abbrev-ref HEAD                                # abort if this IS the base branch
+git symbolic-ref --short refs/remotes/origin/HEAD              # -> origin/<default>
+```
+
+Precedence: user's answer > repo docs (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) > open PR's `baseRefName` > `origin/HEAD`. None resolve → ask.
+
+Find lint/test commands the same way (`package.json` scripts, `Makefile`, `justfile`). None found → say so, don't skip silently.
+
+## Cadence
+
+Run the loop unprompted at: **session start**, **after each commit**, **before push/PR**, **on staleness** (upstream touched your files, CI conflicts, user mentions a merged PR).
+
+Between syncs, commit each coherent unit as soon as it works — repo's commit convention, `git log --oneline` if undocumented. One dirty tree holding three unrelated changes = a three-front conflict.
+
+## Loop
+
+```bash
+git status --short                        # clean, else commit or stash
+git fetch origin <base>
+git rev-list --count HEAD..origin/<base>  # 0 -> done
+git rebase origin/<base>
+```
+
+Stashed → `git stash pop`, re-check status.
+
+Done when: counter is `0`, `git status` clean, no `.orig`/`.rej` left.
+
+Conflict resolved or >10 commits absorbed → run lint + tests. A rebase lands code that never compiled against the new base.
+
+## Conflicts
+
+Resolve now, hunk by hunk, while the work is still in your head.
+
+- Read both sides, understand why the base changed. Never blanket `--ours`/`--theirs`.
+- `git add <file>` → `git rebase --continue`.
+- **Never `--skip`** — it drops one of your commits.
+- `git rebase --abort` restores the pre-rebase state exactly. Use it and ask when: the conflict touches logic you can't attribute, the same file conflicts on 3+ consecutive commits (drifted too far — squash your commits, then rebase again), or resolving means rewriting someone else's change.
+- Then read `git diff origin/<base>...HEAD`: only your work. Upstream code in there = a conflict resolved backwards.
+
+## Push
+
+```bash
+git push --force-with-lease origin HEAD   # branch already pushed, then rebased
+```
+
+`--force-with-lease` only — plain `--force` overwrites a teammate's push. Never force-push a shared branch (`main`, `develop`, release). Never rebase a branch someone else commits to without asking. Push and open PRs only when asked; the loop itself is local.
+
+## Never
+
+- `git merge <base>` into the feature branch — unless `git log --merges --oneline -5 origin/<base>` shows the repo really merges.
+- `git checkout .`, `git reset --hard`, `git clean -fd` on a dirty tree. Commit or stash.
+- `git add -A` sweeping unrelated files. Stage explicitly.
+- Leave a rebase half-finished across turns. Continue or `--abort`.

--- a/.claude/skills/git-sync/SKILL.md
+++ b/.claude/skills/git-sync/SKILL.md
@@ -1,20 +1,23 @@
 ---
 name: git-sync
 description: Keep the current branch rebased on its base branch and the worktree clean. Use at session start, after each commit, before opening or updating a PR, when a rebase conflicts, or when the user says "rebase", "sync", "am I up to date", "merge main".
+allowed-tools: Bash, Read, Edit, Grep, Glob
 ---
 
 Rebase is maintenance, not a finishing move. Keep a **short leash**: never more than a few base commits behind, never more than one unit of work in the tree.
 
-## Resolve `<base>` once per session
+## Setup, once per session
 
 ```bash
-git rev-parse --abbrev-ref HEAD                                # abort if this IS the base branch
-git symbolic-ref --short refs/remotes/origin/HEAD              # -> origin/<default>
+git rev-parse --abbrev-ref HEAD                     # abort if this IS the base branch
+git config rerere.enabled true                      # replays resolutions you already made
+git remote set-head origin -a                       # only if origin/HEAD is missing (fresh CI clone)
+git symbolic-ref --short refs/remotes/origin/HEAD   # -> origin/<default>
 ```
 
-Precedence: user's answer > repo docs (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) > open PR's `baseRefName` > `origin/HEAD`. None resolve → ask.
+`<base>` precedence: user's answer > repo docs (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) > open PR's `baseRefName` > `origin/HEAD`. None resolve → ask.
 
-Find lint/test commands the same way (`package.json` scripts, `Makefile`, `justfile`). None found → say so, don't skip silently.
+Find lint/test commands the same way (`package.json` scripts, `Makefile`, `justfile`) and **require a non-watch variant**: `test` is often `jest --watch` and never returns. Take the `test-ci`-style script, or force `--watchAll=false` / `CI=true`. None found → say so, don't skip silently.
 
 ## Cadence
 
@@ -25,39 +28,46 @@ Between syncs, commit each coherent unit as soon as it works — repo's commit c
 ## Loop
 
 ```bash
-git status --short                        # clean, else commit or stash
+git status --short                         # clean, else: git stash push -u   (-u, or untracked files break the rebase)
 git fetch origin <base>
-git rev-list --count HEAD..origin/<base>  # 0 -> done
+git rev-list --count HEAD..origin/<base>   # 0 -> nothing to do, stop here
+git branch -f backup/<branch>              # net: a bad rebase undoes with git reset --hard backup/<branch>
 git rebase origin/<base>
+git rev-list --count HEAD..origin/<base>   # back to 0? if not, upstream moved — run the loop again
 ```
 
 Stashed → `git stash pop`, re-check status.
 
-Done when: counter is `0`, `git status` clean, no `.orig`/`.rej` left.
+Done when: the second counter reads `0`, `git status` is clean, no `.orig`/`.rej` left.
 
-Conflict resolved or >10 commits absorbed → run lint + tests. A rebase lands code that never compiled against the new base.
+Conflict resolved or >10 commits absorbed → run lint + the non-watch tests. A rebase lands code that never compiled against the new base.
 
 ## Conflicts
 
 Resolve now, hunk by hunk, while the work is still in your head.
 
 - Read both sides, understand why the base changed. Never blanket `--ours`/`--theirs`.
-- `git add <file>` → `git rebase --continue`.
+- `git add <file>` → `GIT_EDITOR=true git rebase --continue`. Without `GIT_EDITOR=true` the editor opens and hangs a non-interactive shell, leaving the rebase half-done.
 - **Never `--skip`** — it drops one of your commits.
-- `git rebase --abort` restores the pre-rebase state exactly. Use it and ask when: the conflict touches logic you can't attribute, the same file conflicts on 3+ consecutive commits (drifted too far — squash your commits, then rebase again), or resolving means rewriting someone else's change.
+- A branch far behind conflicts on many commits in a row. That is the normal cost: persevere commit by commit, `rerere` replays the repeats. Never squash your own commits just to shorten a rebase.
+- `git rebase --abort` restores the pre-rebase state exactly. Use it and ask only on substance: the conflict touches logic you can't attribute, or resolving means rewriting someone else's change.
 - Then read `git diff origin/<base>...HEAD`: only your work. Upstream code in there = a conflict resolved backwards.
 
 ## Push
 
 ```bash
-git push --force-with-lease origin HEAD   # branch already pushed, then rebased
+git push --force-with-lease --force-if-includes origin HEAD   # branch already pushed, then rebased
 ```
 
-`--force-with-lease` only — plain `--force` overwrites a teammate's push. Never force-push a shared branch (`main`, `develop`, release). Never rebase a branch someone else commits to without asking. Push and open PRs only when asked; the loop itself is local.
+Both flags: a background fetch (VS Code auto-fetch, an IDE, another agent) refreshes the remote-tracking ref and makes a stale lease look current — `--force-if-includes` also demands you actually integrated what's on the remote. Rejected → stop and report, never plain `--force`. Never force-push a shared branch (`main`, `develop`, release). Never rebase a branch someone else commits to without asking. Push and open PRs only when asked; the loop itself is local.
+
+## Report
+
+Close every sync with one line: commits absorbed, files that conflicted, backup ref — or `already up to date` when the counter was 0. The user may not read git; the report is how they know what moved.
 
 ## Never
 
-- `git merge <base>` into the feature branch — unless `git log --merges --oneline -5 origin/<base>` shows the repo really merges.
-- `git checkout .`, `git reset --hard`, `git clean -fd` on a dirty tree. Commit or stash.
+- `git merge <base>` into the feature branch — unless `git log --merges --oneline -5 origin/<base>` shows the repo really merges. Rebase flattens merge commits inside your branch; that is intended, don't reach for `--rebase-merges`.
+- `git checkout .`, `git reset --hard`, `git clean -fd` on a dirty tree. Stash instead.
 - `git add -A` sweeping unrelated files. Stage explicitly.
 - Leave a rebase half-finished across turns. Continue or `--abort`.

--- a/.claude/skills/git-sync/SKILL.md
+++ b/.claude/skills/git-sync/SKILL.md
@@ -15,13 +15,13 @@ git remote set-head origin -a                       # only if origin/HEAD is mis
 git symbolic-ref --short refs/remotes/origin/HEAD   # -> origin/<default>
 ```
 
-`<base>` precedence: user's answer > repo docs (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) > open PR's `baseRefName` > `origin/HEAD`. None resolve → ask.
+`<base>` precedence: user's answer > repo docs (`CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`) > open PR's `baseRefName` > `origin/HEAD`. None resolve → ask. Never assume the default branch: on a stacked PR the base is the parent feature branch, and rebasing on the default instead drags the whole parent PR into your diff.
 
 Find lint/test commands the same way (`package.json` scripts, `Makefile`, `justfile`) and **require a non-watch variant**: `test` is often `jest --watch` and never returns. Take the `test-ci`-style script, or force `--watchAll=false` / `CI=true`. None found → say so, don't skip silently.
 
 ## Cadence
 
-Run the loop unprompted at: **session start**, **after each commit**, **before push/PR**, **on staleness** (upstream touched your files, CI conflicts, user mentions a merged PR).
+Sync at **session start**, **after each commit**, **before push/PR**, and **on staleness** (upstream touched your files, CI conflicts, user mentions a merged PR). This is intent, not a guarantee — nothing forces a skill to fire. If session-start syncing must be non-negotiable, say so: it takes a `SessionStart` hook in `.claude/settings.json`, run by the harness, not by this skill.
 
 Between syncs, commit each coherent unit as soon as it works — repo's commit convention, `git log --oneline` if undocumented. One dirty tree holding three unrelated changes = a three-front conflict.
 
@@ -31,39 +31,75 @@ Between syncs, commit each coherent unit as soon as it works — repo's commit c
 git status --short                         # clean, else: git stash push -u   (-u, or untracked files break the rebase)
 git fetch origin <base>
 git rev-list --count HEAD..origin/<base>   # 0 -> nothing to do, stop here
-git branch -f backup/<branch>              # net: a bad rebase undoes with git reset --hard backup/<branch>
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+backup="backup/${branch//\//-}-$(date +%s)"   # flatten slashes: backup/feat/x collides with a future backup/feat ref
+git branch "$backup"                          # a bad rebase undoes with git reset --hard "$backup"
+
 git rebase origin/<base>
 git rev-list --count HEAD..origin/<base>   # back to 0? if not, upstream moved — run the loop again
 ```
 
 Stashed → `git stash pop`, re-check status.
 
-Done when: the second counter reads `0`, `git status` is clean, no `.orig`/`.rej` left.
-
-Conflict resolved or >10 commits absorbed → run lint + the non-watch tests. A rebase lands code that never compiled against the new base.
+The backup is **local** until pushed — useless from another machine or a fresh clone. See Push.
 
 ## Conflicts
 
-Resolve now, hunk by hunk, while the work is still in your head.
+Resolve now, hunk by hunk, while the work is still in your head. Don't stop at the first conflict; record each decision for the report.
 
 - Read both sides, understand why the base changed. Never blanket `--ours`/`--theirs`.
 - `git add <file>` → `GIT_EDITOR=true git rebase --continue`. Without `GIT_EDITOR=true` the editor opens and hangs a non-interactive shell, leaving the rebase half-done.
 - **Never `--skip`** — it drops one of your commits.
 - A branch far behind conflicts on many commits in a row. That is the normal cost: persevere commit by commit, `rerere` replays the repeats. Never squash your own commits just to shorten a rebase.
 - `git rebase --abort` restores the pre-rebase state exactly. Use it and ask only on substance: the conflict touches logic you can't attribute, or resolving means rewriting someone else's change.
-- Then read `git diff origin/<base>...HEAD`: only your work. Upstream code in there = a conflict resolved backwards.
+
+## Verify
+
+A rebase applies cleanly and still leaves a branch that doesn't load. The dangerous breakage is the one git never flagged: upstream deleted a module you still import, or renamed a parameter your call site still passes — no conflict, and a test asserting the old name passes because your code and your test are wrong together.
+
+```bash
+git diff --diff-filter=DR --name-only "$backup"...origin/<base>   # what the base deleted or renamed while you were behind
+```
+
+Grep the branch for every name that comes back — symbols too, not just paths. A surviving reference is a silent regression; fix it now. (Diff from `$backup`, not `HEAD@{1}`: a rebase writes several reflog entries, so `HEAD@{1}` is not reliably the pre-rebase tip.)
+
+Then check only your own diff — a repo-wide lint blows up on pre-existing errors in vendored code and the rule gets dropped forever:
+
+```bash
+<non-watch test script>
+npx eslint $(git diff --name-only origin/<base>...HEAD | grep -E '\.(js|vue)$')
+npx prettier --check $(git diff --name-only origin/<base>...HEAD)
+```
+
+Some repo files aren't formatted to begin with; compare against `$backup`'s state before claiming a formatting regression you didn't cause.
+
+**Anything fails → don't push. Report and stop.** Never a red branch on the remote.
+
+Also read `git diff origin/<base>...HEAD`: only your work. Upstream code in there = a conflict resolved backwards.
 
 ## Push
 
+Push the backup **first** — the force-push is the one irreversible step, and what it can destroy is the _remote_ state a reviewer works from.
+
 ```bash
-git push --force-with-lease --force-if-includes origin HEAD   # branch already pushed, then rebased
+git push origin "$backup"                                      # recoverable pre-rebase state, for the reviewer
+git push --force-with-lease --force-if-includes origin HEAD     # branch already pushed, then rebased
 ```
 
-Both flags: a background fetch (VS Code auto-fetch, an IDE, another agent) refreshes the remote-tracking ref and makes a stale lease look current — `--force-if-includes` also demands you actually integrated what's on the remote. Rejected → stop and report, never plain `--force`. Never force-push a shared branch (`main`, `develop`, release). Never rebase a branch someone else commits to without asking. Push and open PRs only when asked; the loop itself is local.
+Only before an outgoing operation (force-push, opening a PR) — not on every local sync. Delete it when the PR merges: `git push origin --delete "$backup"`, and prune the local ones. Backups nobody dares delete are worse than none.
+
+Both push flags: a background fetch (VS Code auto-fetch, an IDE, another agent) refreshes the remote-tracking ref and makes a stale lease look current — `--force-if-includes` also demands you actually integrated what's on the remote. Rejected → stop and report, never plain `--force`. Never force-push a shared branch (`main`, `develop`, release). Never rebase a branch someone else commits to without asking. Push and open PRs only when asked; the loop itself is local.
 
 ## Report
 
-Close every sync with one line: commits absorbed, files that conflicted, backup ref — or `already up to date` when the counter was 0. The user may not read git; the report is how they know what moved.
+Close every sync with: commits absorbed, commits replayed, backup ref (and whether it's pushed), verify results. Or `already up to date` when the counter was 0.
+
+Then one line **per conflict** — which side won, and why:
+
+> `BsAiInvocationsTab.vue` — dropped the client-side toggle for the server filter added upstream (the base had reimplemented the same feature server-side).
+
+You resolved those conflicts alone; this list is the only thing standing between a plausible-but-wrong resolution and a merged regression.
 
 ## Never
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,14 +17,16 @@ Before committing code:
 ```
 yarn code:lint         # Check for linting errors
 yarn code:fix          # Auto-fix errors and format code
-yarn test              # Run all tests
+yarn test-ci           # Run all tests (yarn test is jest --watch, it never exits)
 ```
 
-## Skills
+## Claude Code Skills
 
-| Skill      | Use for                                                                    |
-| ---------- | -------------------------------------------------------------------------- |
-| `git-sync` | Keeping the branch rebased on `origin/develop` with a clean worktree        |
+Agent skills in `.claude/skills/` (not the product's AI Skills feature).
+
+| Skill      | Use for                                                      |
+| ---------- | ------------------------------------------------------------ |
+| `git-sync` | Keeping the branch rebased on its base with a clean worktree |
 
 ## Available Subagents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,12 @@ yarn code:fix          # Auto-fix errors and format code
 yarn test              # Run all tests
 ```
 
+## Skills
+
+| Skill      | Use for                                                                    |
+| ---------- | -------------------------------------------------------------------------- |
+| `git-sync` | Keeping the branch rebased on `origin/develop` with a clean worktree        |
+
 ## Available Subagents
 
 | Agent              | Use for                        |


### PR DESCRIPTION
Adds a `git-sync` skill that makes Claude rebase the current branch on its base branch continuously — at session start, after each commit and before pushing — instead of leaving one painful rebase at the end of a feature. It covers the sync loop with a checkable completion criterion, conflict handling (`--skip` forbidden, `--abort` as the escape hatch with explicit stop-and-ask cases) and safe pushing (`--force-with-lease` only, never on a shared branch).

The skill is repo-agnostic: it resolves the base branch (user > repo docs > open PR base > `origin/HEAD`) and the lint/test commands from the repository itself, so it works outside this project too. `CLAUDE.md` gains a Skills table pointing to it. Documentation only, no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)