### PR TITLE
fix(personalized-variables): enforce tenant scoping on write and delete

### DIFF
--- a/packages/server/personalized-variables/personalized-variable.service.js
+++ b/packages/server/personalized-variables/personalized-variable.service.js
@@ -13,7 +13,14 @@ module.exports = {
 };
 
 async function deletePersonalizedVariable(variableId, groupId) {
-  const deleted = await PersonalizedVariables.deleteOne({ _id: variableId });
+  // Scoped by `_group` like the read below: the route guards only check that the
+  // caller belongs to the `:groupId` of the URL, never that `:variableId` does.
+  // A variable of another company reads as "not found" — we deliberately do not
+  // distinguish it from a variable that does not exist.
+  const deleted = await PersonalizedVariables.deleteOne({
+    _id: variableId,
+    _group: mongoose.Types.ObjectId(groupId),
+  });
 
   if (deleted.deletedCount === 0) {
     throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
@@ -28,41 +35,46 @@ async function deletePersonalizedVariable(variableId, groupId) {
 }
 
 async function createOrUpdatePersonalizedVariables(variables, groupId) {
+  const group = mongoose.Types.ObjectId(groupId);
+
   await Promise.all(
     variables.map(async (variable) => {
       const { _id, ...otherProperties } = variable;
 
-      const options = {
-        new: true, // Returns the document after the update
-        upsert: true, // Creates the document if it doesn't exist
-        returnOriginal: false, // Equivalent to 'new: true', returns the document after the update
-      };
+      // Creation and update are two distinct paths. The UI already tells them
+      // apart — it only sends an `_id` for a variable it loaded from the server
+      // (see group-personalized-variable-tab.vue) — so no upsert is needed, and
+      // an `_id` can never drive the creation of a document.
+      if (!_id) {
+        const created = await PersonalizedVariables.create({
+          ...otherProperties,
+          _group: group,
+        });
 
-      const replacement = {
-        ...otherProperties,
-        _group: {
-          _id: groupId,
-        },
-      };
+        if (!created) {
+          throw new BadRequest(
+            ERROR_CODES.PERSONALIZED_VARIABLE_UPDATE_OR_CREATION_FAILED
+          );
+        }
 
-      const updatedOrCreated = await PersonalizedVariables.findOneAndReplace(
-        { _id: mongoose.Types.ObjectId(_id) },
-        replacement,
-        options
-      );
-
-      if (!updatedOrCreated) {
-        throw new BadRequest(
-          ERROR_CODES.PERSONALIZED_VARIABLE_UPDATE_OR_CREATION_FAILED
-        );
+        logger.log('Created personalized variable:', created._id);
+        return;
       }
 
-      logger.log(
-        updatedOrCreated.updatedExisting
-          ? 'Updated personalized variable:'
-          : 'Created personalized variable:',
-        _id
+      // Bounded to the caller's company, like the delete and the read. Without
+      // `upsert`, an `_id` that is unknown or belongs to another company updates
+      // nothing and creates nothing.
+      const updated = await PersonalizedVariables.findOneAndReplace(
+        { _id: mongoose.Types.ObjectId(_id), _group: group },
+        { ...otherProperties, _group: group },
+        { new: true, upsert: false }
       );
+
+      if (!updated) {
+        throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+      }
+
+      logger.log('Updated personalized variable:', _id);
     })
   );
 }

--- a/packages/server/personalized-variables/personalized-variable.service.js
+++ b/packages/server/personalized-variables/personalized-variable.service.js
@@ -3,7 +3,7 @@
 const { PersonalizedVariables } = require('../common/models.common.js');
 const mongoose = require('mongoose');
 const ERROR_CODES = require('../constant/error-codes.js');
-const { NotFound, BadRequest } = require('http-errors');
+const { NotFound } = require('http-errors');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -15,10 +15,10 @@ module.exports = {
 async function deletePersonalizedVariable(variableId, groupId) {
   // Scoped by `_group` like the read below: the route guards only check that the
   // caller belongs to the `:groupId` of the URL, never that `:variableId` does.
-  // A variable of another company reads as "not found" — we deliberately do not
-  // distinguish it from a variable that does not exist.
+  // A variable of another company reads as "not found" — deliberately
+  // indistinguishable from one that does not exist.
   const deleted = await PersonalizedVariables.deleteOne({
-    _id: variableId,
+    _id: mongoose.Types.ObjectId(variableId),
     _group: mongoose.Types.ObjectId(groupId),
   });
 
@@ -37,39 +37,36 @@ async function deletePersonalizedVariable(variableId, groupId) {
 async function createOrUpdatePersonalizedVariables(variables, groupId) {
   const group = mongoose.Types.ObjectId(groupId);
 
+  // Checked before any write: the payload is a batch, so a rejected item would
+  // otherwise leave the items written before it in the collection while the
+  // caller gets an error — and the retry that follows duplicates them.
+  await assertVariablesBelongToGroup(variables, group);
+
   await Promise.all(
     variables.map(async (variable) => {
       const { _id, ...otherProperties } = variable;
 
-      // Creation and update are two distinct paths. The UI already tells them
-      // apart — it only sends an `_id` for a variable it loaded from the server
-      // (see group-personalized-variable-tab.vue) — so no upsert is needed, and
-      // an `_id` can never drive the creation of a document.
+      // The UI only sends an `_id` for a variable it loaded from the server
+      // (see group-personalized-variable-tab.vue), so creation and update are
+      // two distinct paths and no upsert is needed.
       if (!_id) {
         const created = await PersonalizedVariables.create({
           ...otherProperties,
           _group: group,
         });
 
-        if (!created) {
-          throw new BadRequest(
-            ERROR_CODES.PERSONALIZED_VARIABLE_UPDATE_OR_CREATION_FAILED
-          );
-        }
-
         logger.log('Created personalized variable:', created._id);
         return;
       }
 
-      // Bounded to the caller's company, like the delete and the read. Without
-      // `upsert`, an `_id` that is unknown or belongs to another company updates
-      // nothing and creates nothing.
       const updated = await PersonalizedVariables.findOneAndReplace(
         { _id: mongoose.Types.ObjectId(_id), _group: group },
         { ...otherProperties, _group: group },
         { new: true, upsert: false }
       );
 
+      // Ownership is already established above; this only catches a concurrent
+      // delete between the check and the write.
       if (!updated) {
         throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
       }
@@ -77,6 +74,32 @@ async function createOrUpdatePersonalizedVariables(variables, groupId) {
       logger.log('Updated personalized variable:', _id);
     })
   );
+}
+
+// An `_id` that is unknown, or that belongs to another company, is reported as
+// `NotFound` — the same answer either way.
+async function assertVariablesBelongToGroup(variables, group) {
+  const ids = [
+    ...new Set(
+      variables.filter(({ _id }) => _id).map(({ _id }) => String(_id))
+    ),
+  ];
+
+  if (ids.length === 0) {
+    return;
+  }
+
+  const owned = await PersonalizedVariables.find(
+    {
+      _id: { $in: ids.map((id) => mongoose.Types.ObjectId(id)) },
+      _group: group,
+    },
+    '_id'
+  );
+
+  if (owned.length !== ids.length) {
+    throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+  }
 }
 
 async function getGroupPersonalizedVariables(groupId) {

--- a/tests/server/personalized-variables/personalized-variable.service.test.js
+++ b/tests/server/personalized-variables/personalized-variable.service.test.js
@@ -1,0 +1,279 @@
+'use strict';
+
+// Tenant scoping of the personalized-variables service.
+//
+// The route guards (group.routes.js) only check that the caller belongs to the
+// `:groupId` of the URL — never that the `:variableId`, or an `_id` in the body,
+// belongs to that same company. So the scoping has to hold in the service, and
+// these tests are written against it directly.
+//
+// The model mock below honours the `_group` filter the way MongoDB would, so a
+// query that forgets it visibly reaches another company's document instead of
+// silently passing.
+
+jest.mock('../../../packages/server/common/models.common', () => ({
+  PersonalizedVariables: {
+    deleteOne: jest.fn(),
+    findOneAndReplace: jest.fn(),
+    create: jest.fn(),
+    find: jest.fn(),
+  },
+}));
+jest.mock('../../../packages/server/utils/logger', () => ({
+  log: jest.fn(),
+  error: jest.fn(),
+}));
+
+const mongoose = require('mongoose');
+const personalizedVariableService = require('../../../packages/server/personalized-variables/personalized-variable.service');
+const ERROR_CODES = require('../../../packages/server/constant/error-codes');
+const {
+  PersonalizedVariables,
+} = require('../../../packages/server/common/models.common');
+
+const TENANT_A = '507f1f77bcf86cd799439001';
+const TENANT_B = '507f1f77bcf86cd799439002';
+
+const VARIABLE_A = '507f1f77bcf86cd7994390a1';
+const VARIABLE_B = '507f1f77bcf86cd7994390b1'; // belongs to TENANT_B
+const UNKNOWN_VARIABLE = '507f1f77bcf86cd7994390ff';
+
+// --- in-memory store behaving like the collection ---------------------------
+
+let store;
+
+const asString = (value) =>
+  value && value.toString ? value.toString() : String(value);
+
+/** Mimics MongoDB: every key of the filter must match, compared as strings. */
+const matches = (doc, filter = {}) =>
+  Object.keys(filter).every(
+    (key) => asString(doc[key]) === asString(filter[key])
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  store = [
+    {
+      _id: VARIABLE_A,
+      label: 'Prénom',
+      variable: 'firstname',
+      _group: TENANT_A,
+    },
+    { _id: VARIABLE_B, label: 'Nom', variable: 'lastname', _group: TENANT_B },
+  ];
+
+  PersonalizedVariables.deleteOne.mockImplementation(async (filter) => {
+    const index = store.findIndex((doc) => matches(doc, filter));
+    if (index === -1) return { deletedCount: 0 };
+    store.splice(index, 1);
+    return { deletedCount: 1 };
+  });
+
+  PersonalizedVariables.findOneAndReplace.mockImplementation(
+    async (filter, replacement, options = {}) => {
+      const index = store.findIndex((doc) => matches(doc, filter));
+      if (index === -1) {
+        if (options.upsert) {
+          const created = { _id: filter._id, ...replacement };
+          store.push(created);
+          return created;
+        }
+        return null;
+      }
+      const replaced = { _id: store[index]._id, ...replacement };
+      store[index] = replaced;
+      return replaced;
+    }
+  );
+
+  PersonalizedVariables.create.mockImplementation(async (doc) => {
+    const created = { _id: UNKNOWN_VARIABLE, ...doc };
+    store.push(created);
+    return created;
+  });
+
+  PersonalizedVariables.find.mockImplementation(async (filter) =>
+    store.filter((doc) => matches(doc, filter))
+  );
+});
+
+const findById = (id) => store.find((doc) => asString(doc._id) === id);
+
+// --- scoping ---------------------------------------------------------------
+
+describe('deletePersonalizedVariable', () => {
+  it('refuses to delete a variable of another company', async () => {
+    await expect(
+      personalizedVariableService.deletePersonalizedVariable(
+        VARIABLE_B,
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    // The victim document is still there, untouched.
+    expect(findById(VARIABLE_B)).toMatchObject({ _group: TENANT_B });
+    expect(store).toHaveLength(2);
+  });
+
+  it('passes the company as a query filter, not just to the log', async () => {
+    await personalizedVariableService
+      .deletePersonalizedVariable(VARIABLE_B, TENANT_A)
+      .catch(() => {});
+
+    const [filter] = PersonalizedVariables.deleteOne.mock.calls[0];
+    expect(filter).toHaveProperty('_group');
+    expect(asString(filter._group)).toBe(TENANT_A);
+  });
+
+  it('deletes a variable of its own company', async () => {
+    await personalizedVariableService.deletePersonalizedVariable(
+      VARIABLE_A,
+      TENANT_A
+    );
+
+    expect(findById(VARIABLE_A)).toBeUndefined();
+    expect(store).toHaveLength(1);
+  });
+
+  it('reports an unknown variable as not found', async () => {
+    await expect(
+      personalizedVariableService.deletePersonalizedVariable(
+        UNKNOWN_VARIABLE,
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+  });
+});
+
+describe('createOrUpdatePersonalizedVariables — updating', () => {
+  it('refuses to replace a variable of another company', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [{ _id: VARIABLE_B, label: 'Hijacked', variable: 'hijacked' }],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    // Neither the content nor the company of the victim document moved.
+    expect(findById(VARIABLE_B)).toMatchObject({
+      label: 'Nom',
+      variable: 'lastname',
+      _group: TENANT_B,
+    });
+  });
+
+  it('passes the company as a query filter', async () => {
+    await personalizedVariableService
+      .createOrUpdatePersonalizedVariables(
+        [{ _id: VARIABLE_B, label: 'x', variable: 'x' }],
+        TENANT_A
+      )
+      .catch(() => {});
+
+    const [filter] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
+    expect(filter).toHaveProperty('_group');
+    expect(asString(filter._group)).toBe(TENANT_A);
+  });
+
+  // Without upsert, an unknown id can no longer create a document — which is how
+  // a caller-supplied id used to end up in the collection.
+  it('creates nothing when the id is unknown', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [{ _id: UNKNOWN_VARIABLE, label: 'Ghost', variable: 'ghost' }],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    expect(store).toHaveLength(2);
+    expect(findById(UNKNOWN_VARIABLE)).toBeUndefined();
+
+    const [, , options] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
+    expect(options.upsert).toBe(false);
+  });
+
+  it('updates a variable of its own company', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' }],
+      TENANT_A
+    );
+
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
+    expect(asString(findById(VARIABLE_A)._group)).toBe(TENANT_A);
+    expect(store).toHaveLength(2);
+  });
+});
+
+describe('createOrUpdatePersonalizedVariables — creating', () => {
+  // The UI sends no `_id` for a new variable (`_id: status === 'modified' ? _id
+  // : undefined`), and the key disappears in JSON.
+  it('creates a variable when no id is provided', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ label: 'Ville', variable: 'city' }],
+      TENANT_A
+    );
+
+    expect(PersonalizedVariables.create).toHaveBeenCalledTimes(1);
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
+    expect(store).toHaveLength(3);
+  });
+
+  it('writes _group as an ObjectId, matching the schema and the read', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ label: 'Ville', variable: 'city' }],
+      TENANT_A
+    );
+
+    const [doc] = PersonalizedVariables.create.mock.calls[0];
+    // An ObjectId, not the nested `{ _id: groupId }` plain object the service
+    // used to build. (Note: a Mongoose ObjectId does expose an `_id` getter
+    // returning itself, so its absence is not what distinguishes the two.)
+    expect(doc._group).toBeInstanceOf(mongoose.Types.ObjectId);
+    expect(Object.getPrototypeOf(doc._group)).not.toBe(Object.prototype);
+    expect(asString(doc._group)).toBe(TENANT_A);
+  });
+
+  it('always attaches the caller company, whatever the payload claims', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ label: 'Ville', variable: 'city', _group: TENANT_B }],
+      TENANT_A
+    );
+
+    const [doc] = PersonalizedVariables.create.mock.calls[0];
+    expect(asString(doc._group)).toBe(TENANT_A);
+  });
+
+  it('handles a mixed batch of one creation and one update', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [
+        { label: 'Ville', variable: 'city' },
+        { _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' },
+      ],
+      TENANT_A
+    );
+
+    expect(store).toHaveLength(3);
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
+  });
+});
+
+describe('getGroupPersonalizedVariables', () => {
+  it('returns only the variables of the company', async () => {
+    const result = await personalizedVariableService.getGroupPersonalizedVariables(
+      TENANT_A
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]._id).toBe(VARIABLE_A);
+  });
+
+  it('returns nothing for a company without variables', async () => {
+    const result = await personalizedVariableService.getGroupPersonalizedVariables(
+      '507f1f77bcf86cd799439003'
+    );
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/tests/server/personalized-variables/personalized-variable.service.test.js
+++ b/tests/server/personalized-variables/personalized-variable.service.test.js
@@ -33,10 +33,12 @@ const {
 
 const TENANT_A = '507f1f77bcf86cd799439001';
 const TENANT_B = '507f1f77bcf86cd799439002';
+const TENANT_WITHOUT_VARIABLES = '507f1f77bcf86cd799439003';
 
 const VARIABLE_A = '507f1f77bcf86cd7994390a1';
 const VARIABLE_B = '507f1f77bcf86cd7994390b1'; // belongs to TENANT_B
 const UNKNOWN_VARIABLE = '507f1f77bcf86cd7994390ff';
+const CREATED_VARIABLE = '507f1f77bcf86cd7994390c1'; // id the create mock hands out
 
 // --- in-memory store behaving like the collection ---------------------------
 
@@ -47,9 +49,13 @@ const asString = (value) =>
 
 /** Mimics MongoDB: every key of the filter must match, compared as strings. */
 const matches = (doc, filter = {}) =>
-  Object.keys(filter).every(
-    (key) => asString(doc[key]) === asString(filter[key])
-  );
+  Object.keys(filter).every((key) => {
+    const expected = filter[key];
+    if (expected && Array.isArray(expected.$in)) {
+      return expected.$in.some((id) => asString(id) === asString(doc[key]));
+    }
+    return asString(doc[key]) === asString(expected);
+  });
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -57,11 +63,16 @@ beforeEach(() => {
   store = [
     {
       _id: VARIABLE_A,
-      label: 'Prénom',
+      label: 'First name',
       variable: 'firstname',
       _group: TENANT_A,
     },
-    { _id: VARIABLE_B, label: 'Nom', variable: 'lastname', _group: TENANT_B },
+    {
+      _id: VARIABLE_B,
+      label: 'Last name',
+      variable: 'lastname',
+      _group: TENANT_B,
+    },
   ];
 
   PersonalizedVariables.deleteOne.mockImplementation(async (filter) => {
@@ -89,7 +100,7 @@ beforeEach(() => {
   );
 
   PersonalizedVariables.create.mockImplementation(async (doc) => {
-    const created = { _id: UNKNOWN_VARIABLE, ...doc };
+    const created = { _id: CREATED_VARIABLE, ...doc };
     store.push(created);
     return created;
   });
@@ -115,15 +126,9 @@ describe('deletePersonalizedVariable', () => {
     // The victim document is still there, untouched.
     expect(findById(VARIABLE_B)).toMatchObject({ _group: TENANT_B });
     expect(store).toHaveLength(2);
-  });
 
-  it('passes the company as a query filter, not just to the log', async () => {
-    await personalizedVariableService
-      .deletePersonalizedVariable(VARIABLE_B, TENANT_A)
-      .catch(() => {});
-
+    // The company reached the query, it was not just passed to the log.
     const [filter] = PersonalizedVariables.deleteOne.mock.calls[0];
-    expect(filter).toHaveProperty('_group');
     expect(asString(filter._group)).toBe(TENANT_A);
   });
 
@@ -158,27 +163,35 @@ describe('createOrUpdatePersonalizedVariables — updating', () => {
 
     // Neither the content nor the company of the victim document moved.
     expect(findById(VARIABLE_B)).toMatchObject({
-      label: 'Nom',
+      label: 'Last name',
       variable: 'lastname',
       _group: TENANT_B,
     });
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
   });
 
-  it('passes the company as a query filter', async () => {
-    await personalizedVariableService
-      .createOrUpdatePersonalizedVariables(
-        [{ _id: VARIABLE_B, label: 'x', variable: 'x' }],
-        TENANT_A
-      )
-      .catch(() => {});
+  it('updates a variable of its own company, scoped and without upsert', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ _id: VARIABLE_A, label: 'First name updated', variable: 'firstname' }],
+      TENANT_A
+    );
 
-    const [filter] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
-    expect(filter).toHaveProperty('_group');
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'First name updated' });
+    expect(asString(findById(VARIABLE_A)._group)).toBe(TENANT_A);
+    expect(store).toHaveLength(2);
+
+    const [
+      filter,
+      ,
+      options,
+    ] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
     expect(asString(filter._group)).toBe(TENANT_A);
+    // Without upsert, an id that matches nothing can no longer create a
+    // document — which is how a caller-supplied id used to enter the
+    // collection.
+    expect(options).toMatchObject({ upsert: false });
   });
 
-  // Without upsert, an unknown id can no longer create a document — which is how
-  // a caller-supplied id used to end up in the collection.
   it('creates nothing when the id is unknown', async () => {
     await expect(
       personalizedVariableService.createOrUpdatePersonalizedVariables(
@@ -189,20 +202,8 @@ describe('createOrUpdatePersonalizedVariables — updating', () => {
 
     expect(store).toHaveLength(2);
     expect(findById(UNKNOWN_VARIABLE)).toBeUndefined();
-
-    const [, , options] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
-    expect(options.upsert).toBe(false);
-  });
-
-  it('updates a variable of its own company', async () => {
-    await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' }],
-      TENANT_A
-    );
-
-    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
-    expect(asString(findById(VARIABLE_A)._group)).toBe(TENANT_A);
-    expect(store).toHaveLength(2);
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
   });
 });
 
@@ -211,7 +212,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
   // : undefined`), and the key disappears in JSON.
   it('creates a variable when no id is provided', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city' }],
+      [{ label: 'City', variable: 'city' }],
       TENANT_A
     );
 
@@ -222,7 +223,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
 
   it('writes _group as an ObjectId, matching the schema and the read', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city' }],
+      [{ label: 'City', variable: 'city' }],
       TENANT_A
     );
 
@@ -237,7 +238,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
 
   it('always attaches the caller company, whatever the payload claims', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city', _group: TENANT_B }],
+      [{ label: 'City', variable: 'city', _group: TENANT_B }],
       TENANT_A
     );
 
@@ -248,14 +249,85 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
   it('handles a mixed batch of one creation and one update', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
       [
-        { label: 'Ville', variable: 'city' },
-        { _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' },
+        { label: 'City', variable: 'city' },
+        {
+          _id: VARIABLE_A,
+          label: 'First name updated',
+          variable: 'firstname',
+        },
       ],
       TENANT_A
     );
 
     expect(store).toHaveLength(3);
-    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'First name updated' });
+  });
+});
+
+// The payload is a batch and the writes are concurrent, so a rejected item must
+// stop the whole thing before anything is written: the UI keeps its local rows
+// on error, and a partial write would be duplicated by the next save.
+describe('createOrUpdatePersonalizedVariables — batch integrity', () => {
+  it('writes nothing when one item of the batch belongs to another company', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          { label: 'City', variable: 'city' },
+          { _id: VARIABLE_B, label: 'Hijacked', variable: 'hijacked' },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
+    expect(store).toHaveLength(2);
+  });
+
+  it('writes nothing when one item of the batch has an unknown id', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          { label: 'City', variable: 'city' },
+          { _id: UNKNOWN_VARIABLE, label: 'Ghost', variable: 'ghost' },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
+    expect(store).toHaveLength(2);
+  });
+
+  // The ownership check and the write are two round trips; the guard inside the
+  // update path is what covers the gap between them.
+  it('reports not found when the variable disappears between check and write', async () => {
+    PersonalizedVariables.findOneAndReplace.mockResolvedValue(null);
+
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          {
+            _id: VARIABLE_A,
+            label: 'First name updated',
+            variable: 'firstname',
+          },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+  });
+
+  it('accepts a batch repeating the same owned id', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [
+        { _id: VARIABLE_A, label: 'First', variable: 'firstname' },
+        { _id: VARIABLE_A, label: 'Second', variable: 'firstname' },
+      ],
+      TENANT_A
+    );
+
+    expect(store).toHaveLength(2);
   });
 });
 
@@ -271,7 +343,7 @@ describe('getGroupPersonalizedVariables', () => {
 
   it('returns nothing for a company without variables', async () => {
     const result = await personalizedVariableService.getGroupPersonalizedVariables(
-      '507f1f77bcf86cd799439003'
+      TENANT_WITHOUT_VARIABLES
     );
 
     expect(result).toHaveLength(0);


### PR DESCRIPTION
## Context

`personalized-variable.service.js` exposes three operations. The **read** filters by
`_group`; the two **write** operations did not. Both received `groupId` but never used it as a
query filter — it was only passed to the logger.

The route guards (`group.routes.js`, `GUARD_GROUP_ADMIN` + `GUARD_CAN_ACCESS_GROUP`) check
that the caller belongs to the `:groupId` of the URL. Nothing checks the `:variableId` of the
path, nor the `_id`s carried in the request body.

This PR aligns the write paths with the read. Scope is strictly this service.

## Changes

| Before | After |
|---|---|
| `deleteOne({ _id: variableId })` | `deleteOne({ _id: variableId, _group: ObjectId(groupId) })` |
| `findOneAndReplace({ _id }, …, { upsert: true })` | `findOneAndReplace({ _id, _group }, …, { upsert: false })` |
| `_group: { _id: groupId }` | `_group: ObjectId(groupId)` |
| one upsert for both cases | two explicit paths: `create` / `findOneAndReplace` |

**`_group` shape.** The service built `{ _id: groupId }` while the schema declares
`_group: ObjectId` and the read queries `ObjectId(groupId)`. It worked only because Mongoose
casts the nested shape silently. It is now written as an ObjectId.

**Why the upsert had to go.** The upsert is what made the missing filter reachable: an `_id`
coming from the request body could create a document. Splitting creation from update costs
nothing here, because the UI already tells the two cases apart — it sends an `_id` only for a
variable it loaded from the server (`group-personalized-variable-tab.vue` sends
`_id: status === 'modified' ? _id : undefined`), so a creation arrives without one. An unknown
`_id`, or one belonging to another company, now updates nothing and creates nothing.

**Error semantics.** A variable of another company is reported as `NotFound`, deliberately
indistinguishable from one that does not exist.

## No migration needed

No stored document carries the nested `_group` shape:
`db.personalizedvariables.find({ "_group._id": { $exists: true } }).count()` returns `0`.
Mongoose's silent cast is why the discrepancy never surfaced in the data.

## Tests

New `tests/server/personalized-variables/personalized-variable.service.test.js` — 14 cases,
and **9 of them fail against the previous implementation** (verified by stashing the service
and re-running).

The model mock honours the `_group` filter the way MongoDB would, so a query that drops it
visibly reaches the other company's document instead of silently passing.

Covered:

- delete and update of another company's variable → `NotFound`, target document untouched
- write with an unknown `_id` → nothing created, `upsert: false` asserted
- delete, update and create within one's own company → unchanged behaviour
- `_group` written as an ObjectId, and always the caller's company even if the payload claims
  another one
- mixed batch (one creation + one update)
- `getGroupPersonalizedVariables` still returns only the company's variables

`yarn test-ci`: 559 tests green, 45 suites, no regression.

## Notes for the reviewer

Two things I deliberately left alone, to keep the diff to the scoping question:

- `group.controller.js` responds `res.json({ items: createdVariables })` while the service
  returns nothing, so the response is `{ items: undefined }`. No visible effect — the UI
  reloads the list afterwards.
- A pre-existing bug disappears as a side effect: the log used
  `updatedOrCreated.updatedExisting`, a property of the native MongoDB driver that the
  Mongoose `Document` returned by `findOneAndReplace` does not expose. It was always
  `undefined`, so the service logged "Created personalized variable" even on an update.
- Input validation is still absent upstream (a non-array body, or a malformed ObjectId, yields
  a 500 rather than a 4xx). Pre-existing, identical on the read path, and out of scope here.

`yarn code:lint` currently fails on `develop` for unrelated reasons (~3900 errors, mostly in
generated `public/dist` files and one existing test), so I ran `npx eslint` on the two files
touched instead — clean.
