### PR TITLE
fix(personalized-variables): make the write batch all-or-nothing

### DIFF
--- a/packages/server/personalized-variables/personalized-variable.service.js
+++ b/packages/server/personalized-variables/personalized-variable.service.js
@@ -3,7 +3,7 @@
 const { PersonalizedVariables } = require('../common/models.common.js');
 const mongoose = require('mongoose');
 const ERROR_CODES = require('../constant/error-codes.js');
-const { NotFound, BadRequest } = require('http-errors');
+const { NotFound } = require('http-errors');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -15,10 +15,10 @@ module.exports = {
 async function deletePersonalizedVariable(variableId, groupId) {
   // Scoped by `_group` like the read below: the route guards only check that the
   // caller belongs to the `:groupId` of the URL, never that `:variableId` does.
-  // A variable of another company reads as "not found" — we deliberately do not
-  // distinguish it from a variable that does not exist.
+  // A variable of another company reads as "not found" — deliberately
+  // indistinguishable from one that does not exist.
   const deleted = await PersonalizedVariables.deleteOne({
-    _id: variableId,
+    _id: mongoose.Types.ObjectId(variableId),
     _group: mongoose.Types.ObjectId(groupId),
   });
 
@@ -37,39 +37,36 @@ async function deletePersonalizedVariable(variableId, groupId) {
 async function createOrUpdatePersonalizedVariables(variables, groupId) {
   const group = mongoose.Types.ObjectId(groupId);
 
+  // Checked before any write: the payload is a batch, so a rejected item would
+  // otherwise leave the items written before it in the collection while the
+  // caller gets an error — and the retry that follows duplicates them.
+  await assertVariablesBelongToGroup(variables, group);
+
   await Promise.all(
     variables.map(async (variable) => {
       const { _id, ...otherProperties } = variable;
 
-      // Creation and update are two distinct paths. The UI already tells them
-      // apart — it only sends an `_id` for a variable it loaded from the server
-      // (see group-personalized-variable-tab.vue) — so no upsert is needed, and
-      // an `_id` can never drive the creation of a document.
+      // The UI only sends an `_id` for a variable it loaded from the server
+      // (see group-personalized-variable-tab.vue), so creation and update are
+      // two distinct paths and no upsert is needed.
       if (!_id) {
         const created = await PersonalizedVariables.create({
           ...otherProperties,
           _group: group,
         });
 
-        if (!created) {
-          throw new BadRequest(
-            ERROR_CODES.PERSONALIZED_VARIABLE_UPDATE_OR_CREATION_FAILED
-          );
-        }
-
         logger.log('Created personalized variable:', created._id);
         return;
       }
 
-      // Bounded to the caller's company, like the delete and the read. Without
-      // `upsert`, an `_id` that is unknown or belongs to another company updates
-      // nothing and creates nothing.
       const updated = await PersonalizedVariables.findOneAndReplace(
         { _id: mongoose.Types.ObjectId(_id), _group: group },
         { ...otherProperties, _group: group },
         { new: true, upsert: false }
       );
 
+      // Ownership is already established above; this only catches a concurrent
+      // delete between the check and the write.
       if (!updated) {
         throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
       }
@@ -77,6 +74,32 @@ async function createOrUpdatePersonalizedVariables(variables, groupId) {
       logger.log('Updated personalized variable:', _id);
     })
   );
+}
+
+// An `_id` that is unknown, or that belongs to another company, is reported as
+// `NotFound` — the same answer either way.
+async function assertVariablesBelongToGroup(variables, group) {
+  const ids = [
+    ...new Set(
+      variables.filter(({ _id }) => _id).map(({ _id }) => String(_id))
+    ),
+  ];
+
+  if (ids.length === 0) {
+    return;
+  }
+
+  const owned = await PersonalizedVariables.find(
+    {
+      _id: { $in: ids.map((id) => mongoose.Types.ObjectId(id)) },
+      _group: group,
+    },
+    '_id'
+  );
+
+  if (owned.length !== ids.length) {
+    throw new NotFound(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+  }
 }
 
 async function getGroupPersonalizedVariables(groupId) {

--- a/tests/server/personalized-variables/personalized-variable.service.test.js
+++ b/tests/server/personalized-variables/personalized-variable.service.test.js
@@ -33,10 +33,12 @@ const {
 
 const TENANT_A = '507f1f77bcf86cd799439001';
 const TENANT_B = '507f1f77bcf86cd799439002';
+const TENANT_WITHOUT_VARIABLES = '507f1f77bcf86cd799439003';
 
 const VARIABLE_A = '507f1f77bcf86cd7994390a1';
 const VARIABLE_B = '507f1f77bcf86cd7994390b1'; // belongs to TENANT_B
 const UNKNOWN_VARIABLE = '507f1f77bcf86cd7994390ff';
+const CREATED_VARIABLE = '507f1f77bcf86cd7994390c1'; // id the create mock hands out
 
 // --- in-memory store behaving like the collection ---------------------------
 
@@ -47,9 +49,13 @@ const asString = (value) =>
 
 /** Mimics MongoDB: every key of the filter must match, compared as strings. */
 const matches = (doc, filter = {}) =>
-  Object.keys(filter).every(
-    (key) => asString(doc[key]) === asString(filter[key])
-  );
+  Object.keys(filter).every((key) => {
+    const expected = filter[key];
+    if (expected && Array.isArray(expected.$in)) {
+      return expected.$in.some((id) => asString(id) === asString(doc[key]));
+    }
+    return asString(doc[key]) === asString(expected);
+  });
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -57,11 +63,16 @@ beforeEach(() => {
   store = [
     {
       _id: VARIABLE_A,
-      label: 'Prénom',
+      label: 'First name',
       variable: 'firstname',
       _group: TENANT_A,
     },
-    { _id: VARIABLE_B, label: 'Nom', variable: 'lastname', _group: TENANT_B },
+    {
+      _id: VARIABLE_B,
+      label: 'Last name',
+      variable: 'lastname',
+      _group: TENANT_B,
+    },
   ];
 
   PersonalizedVariables.deleteOne.mockImplementation(async (filter) => {
@@ -89,7 +100,7 @@ beforeEach(() => {
   );
 
   PersonalizedVariables.create.mockImplementation(async (doc) => {
-    const created = { _id: UNKNOWN_VARIABLE, ...doc };
+    const created = { _id: CREATED_VARIABLE, ...doc };
     store.push(created);
     return created;
   });
@@ -115,15 +126,9 @@ describe('deletePersonalizedVariable', () => {
     // The victim document is still there, untouched.
     expect(findById(VARIABLE_B)).toMatchObject({ _group: TENANT_B });
     expect(store).toHaveLength(2);
-  });
 
-  it('passes the company as a query filter, not just to the log', async () => {
-    await personalizedVariableService
-      .deletePersonalizedVariable(VARIABLE_B, TENANT_A)
-      .catch(() => {});
-
+    // The company reached the query, it was not just passed to the log.
     const [filter] = PersonalizedVariables.deleteOne.mock.calls[0];
-    expect(filter).toHaveProperty('_group');
     expect(asString(filter._group)).toBe(TENANT_A);
   });
 
@@ -158,27 +163,35 @@ describe('createOrUpdatePersonalizedVariables — updating', () => {
 
     // Neither the content nor the company of the victim document moved.
     expect(findById(VARIABLE_B)).toMatchObject({
-      label: 'Nom',
+      label: 'Last name',
       variable: 'lastname',
       _group: TENANT_B,
     });
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
   });
 
-  it('passes the company as a query filter', async () => {
-    await personalizedVariableService
-      .createOrUpdatePersonalizedVariables(
-        [{ _id: VARIABLE_B, label: 'x', variable: 'x' }],
-        TENANT_A
-      )
-      .catch(() => {});
+  it('updates a variable of its own company, scoped and without upsert', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [{ _id: VARIABLE_A, label: 'First name updated', variable: 'firstname' }],
+      TENANT_A
+    );
 
-    const [filter] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
-    expect(filter).toHaveProperty('_group');
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'First name updated' });
+    expect(asString(findById(VARIABLE_A)._group)).toBe(TENANT_A);
+    expect(store).toHaveLength(2);
+
+    const [
+      filter,
+      ,
+      options,
+    ] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
     expect(asString(filter._group)).toBe(TENANT_A);
+    // Without upsert, an id that matches nothing can no longer create a
+    // document — which is how a caller-supplied id used to enter the
+    // collection.
+    expect(options).toMatchObject({ upsert: false });
   });
 
-  // Without upsert, an unknown id can no longer create a document — which is how
-  // a caller-supplied id used to end up in the collection.
   it('creates nothing when the id is unknown', async () => {
     await expect(
       personalizedVariableService.createOrUpdatePersonalizedVariables(
@@ -189,20 +202,8 @@ describe('createOrUpdatePersonalizedVariables — updating', () => {
 
     expect(store).toHaveLength(2);
     expect(findById(UNKNOWN_VARIABLE)).toBeUndefined();
-
-    const [, , options] = PersonalizedVariables.findOneAndReplace.mock.calls[0];
-    expect(options.upsert).toBe(false);
-  });
-
-  it('updates a variable of its own company', async () => {
-    await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' }],
-      TENANT_A
-    );
-
-    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
-    expect(asString(findById(VARIABLE_A)._group)).toBe(TENANT_A);
-    expect(store).toHaveLength(2);
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
   });
 });
 
@@ -211,7 +212,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
   // : undefined`), and the key disappears in JSON.
   it('creates a variable when no id is provided', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city' }],
+      [{ label: 'City', variable: 'city' }],
       TENANT_A
     );
 
@@ -222,7 +223,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
 
   it('writes _group as an ObjectId, matching the schema and the read', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city' }],
+      [{ label: 'City', variable: 'city' }],
       TENANT_A
     );
 
@@ -237,7 +238,7 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
 
   it('always attaches the caller company, whatever the payload claims', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
-      [{ label: 'Ville', variable: 'city', _group: TENANT_B }],
+      [{ label: 'City', variable: 'city', _group: TENANT_B }],
       TENANT_A
     );
 
@@ -248,14 +249,85 @@ describe('createOrUpdatePersonalizedVariables — creating', () => {
   it('handles a mixed batch of one creation and one update', async () => {
     await personalizedVariableService.createOrUpdatePersonalizedVariables(
       [
-        { label: 'Ville', variable: 'city' },
-        { _id: VARIABLE_A, label: 'Prénom modifié', variable: 'firstname' },
+        { label: 'City', variable: 'city' },
+        {
+          _id: VARIABLE_A,
+          label: 'First name updated',
+          variable: 'firstname',
+        },
       ],
       TENANT_A
     );
 
     expect(store).toHaveLength(3);
-    expect(findById(VARIABLE_A)).toMatchObject({ label: 'Prénom modifié' });
+    expect(findById(VARIABLE_A)).toMatchObject({ label: 'First name updated' });
+  });
+});
+
+// The payload is a batch and the writes are concurrent, so a rejected item must
+// stop the whole thing before anything is written: the UI keeps its local rows
+// on error, and a partial write would be duplicated by the next save.
+describe('createOrUpdatePersonalizedVariables — batch integrity', () => {
+  it('writes nothing when one item of the batch belongs to another company', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          { label: 'City', variable: 'city' },
+          { _id: VARIABLE_B, label: 'Hijacked', variable: 'hijacked' },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
+    expect(PersonalizedVariables.findOneAndReplace).not.toHaveBeenCalled();
+    expect(store).toHaveLength(2);
+  });
+
+  it('writes nothing when one item of the batch has an unknown id', async () => {
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          { label: 'City', variable: 'city' },
+          { _id: UNKNOWN_VARIABLE, label: 'Ghost', variable: 'ghost' },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+
+    expect(PersonalizedVariables.create).not.toHaveBeenCalled();
+    expect(store).toHaveLength(2);
+  });
+
+  // The ownership check and the write are two round trips; the guard inside the
+  // update path is what covers the gap between them.
+  it('reports not found when the variable disappears between check and write', async () => {
+    PersonalizedVariables.findOneAndReplace.mockResolvedValue(null);
+
+    await expect(
+      personalizedVariableService.createOrUpdatePersonalizedVariables(
+        [
+          {
+            _id: VARIABLE_A,
+            label: 'First name updated',
+            variable: 'firstname',
+          },
+        ],
+        TENANT_A
+      )
+    ).rejects.toThrow(ERROR_CODES.PERSONALIZED_VARIABLE_NOT_FOUND);
+  });
+
+  it('accepts a batch repeating the same owned id', async () => {
+    await personalizedVariableService.createOrUpdatePersonalizedVariables(
+      [
+        { _id: VARIABLE_A, label: 'First', variable: 'firstname' },
+        { _id: VARIABLE_A, label: 'Second', variable: 'firstname' },
+      ],
+      TENANT_A
+    );
+
+    expect(store).toHaveLength(2);
   });
 });
 
@@ -271,7 +343,7 @@ describe('getGroupPersonalizedVariables', () => {
 
   it('returns nothing for a company without variables', async () => {
     const result = await personalizedVariableService.getGroupPersonalizedVariables(
-      '507f1f77bcf86cd799439003'
+      TENANT_WITHOUT_VARIABLES
     );
 
     expect(result).toHaveLength(0);


### PR DESCRIPTION
Stacked on top of #1080 — targets `fix/personalized-variables-tenant-scoping`, not `develop`.

The tenant scoping of #1080 is correct and untouched here: the three `_group` filters stay as
they are, and the 14 guarantees its test file asserts are all still covered (two tests were
merged into neighbours, no assertion was dropped). This PR only adds a check *before* the
writes, plus two secondary points found while reviewing.

## The batch is no longer written partially

`POST /groups/:groupId/personalized-variables` takes an **array** and writes it through
`Promise.all`. #1080 turned an update that always succeeded (`upsert: true`) into one that
can `throw NotFound` — and `Promise.all` rejects while the items written before the failing
one stay in the collection.

Reachable without doing anything unusual:

1. Two admins of the same company, or simply two open tabs.
2. Tab A deletes the variable *Prénom*.
3. Tab B, opened earlier, adds *Ville*, edits *Prénom*, saves — it sends
   `[{ label: 'Ville' }, { _id: <Prénom>, … }]`.
4. *Ville* is created and persisted. The update of *Prénom* rejects → **404 to the client**.
5. `group-personalized-variable-tab.vue` only calls `getVariables()` in the `try`, so *Ville*
   keeps `status: 'new'` in the local state.
6. The user saves again → ***Ville* is created a second time.** Nothing in the schema
   prevents the duplicate.

Ownership of every `_id` of the payload is now established **before any write**, in one query:

```js
await assertVariablesBelongToGroup(variables, group);   // before the loop
```

- Ids are deduplicated (`Set` of strings): without it a payload repeating the same `_id`
  would give `owned.length (1) !== ids.length (2)` and answer 404 on a legitimate request.
- The check returns immediately when the batch contains only creations, so a page of new
  variables does not pay the extra query. Cost: +1 `find` per POST carrying at least one `_id`.
- The `if (!updated)` guard inside the loop stays, but its role changes: it no longer detects
  a cross-tenant write (done upfront), only a delete concurrent with the write. Commented as
  such, and covered by a test.

Error semantics are unchanged: same `NotFound`, same error code, raised before the writes
instead of during them.

This is not a transaction — the race window remains, but it shrinks from "any stale tab" to
the few milliseconds between the two round trips.

**The UI is deliberately untouched.** The root cause is gone server-side, and calling
`getVariables()` in the `catch` of `onSubmit` would discard every row the user typed on any
network error.

## Unreachable branch removed

`Model.create` rejects on failure — it never resolves falsy, so `if (!created) throw
BadRequest(…)` could not run (coverage confirmed the line was never hit). The `BadRequest`
import goes with it. Behaviour is unchanged: a real create failure rejects and comes out of
`apiErrorHandler` (`packages/server/index.js:331`) as a 500, before as after — a Mongoose
`ValidationError` carries no `status`. Mapping it to a 4xx is a separate, pre-existing gap.

Side effect: `PERSONALIZED_VARIABLE_UPDATE_OR_CREATION_FAILED` is now unreferenced — left in
`error-codes.js` rather than removing an error string a client may expect.

## Cast consistency

`_id: variableId` raw next to `_group: ObjectId(groupId)` in the delete filter, while the
update path cast both. It worked (Mongoose casts filters against the schema) but read as an
oversight in the very query the PR secures. A malformed id still yields a 500, from the
`ObjectId()` call instead of Mongoose's internal `CastError` — no change for the client.

## Note for the reviewer: validation is already enforced

Worth recording, because it looks like a gap and is not one. `findOneAndReplace` does **not**
skip the schema here: `Query.prototype._findOneAndReplace` builds a real document
(`new this.model(this._update, null, true)`) and calls `castedDoc.validate(...)`
**unconditionally** (`mongoose@5.13.22`, `lib/query.js:3512`). Passing `runValidators: true`
on this path changes nothing — the option is not even read there, it is forwarded to the
driver, which ignores it (its command is built from a whitelist). So a replacement missing
`label` or `variable` is already refused, before and after #1080.

## Tests

- **Both `.catch(() => {})` are gone.** They said "I expect an error but I will not check
  which one" — the test passed even if the service blew up on an unrelated `TypeError`. The
  `_group` filter assertions move into the matching `rejects.toThrow(…)` test for the delete,
  and into the happy-path test (where `findOneAndReplace` is actually called) for the update.
- Added: mixed batch containing another company's variable → `create` **never called**, store
  untouched; same with an unknown `_id`; batch repeating an owned `_id` → accepted; document
  disappearing between the check and the write → `NotFound`.
- The `find` mock understands `$in`, so the new check is evaluated the way MongoDB would.
- Fixtures in English (AGENTS.md keeps French for i18n only), and the create mock hands out a
  `CREATED_VARIABLE` id distinct from `UNKNOWN_VARIABLE` — it used to return the very id that,
  two tests down, means "this must create nothing".

| | |
|---|---|
| Test file | 16 tests green (14 before) |
| Full suite (`jest`, as `test-ci` runs it) | **561 tests / 45 suites green** |
| Against the service of `develop` | **10 of 16 fail** (9 of 14 before) |
| Service coverage | 94% lines, **100% branches** (only the `catch` of `getGroupPersonalizedVariables` left) |
| `npx eslint` + `prettier --check` on both files | clean |

`yarn code:lint` still fails on `develop` for unrelated reasons (~3900 errors, mostly generated
`public/dist` files), so the two touched files were linted directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
