### PR TITLE
fix(images): typer les réponses d'après les octets et plafonner les boucles

### DIFF
--- a/packages/server/image/image.controller.js
+++ b/packages/server/image/image.controller.js
@@ -107,8 +107,20 @@ function handleSharpStream(req, res, next, pipeline) {
   const { path } = req;
   const { imageName } = req.params;
 
+  // Without this, a sharp failure (an input it can't re-encode, a truncated
+  // upload) leaves the client with a half-written 200 that no cache stores — so
+  // the browser retries forever. Fail loudly instead.
+  const onPipelineError = (e) => {
+    console.log(red('[IMAGE] sharp pipeline error'), path);
+    console.log(inspect(e));
+    if (res.headersSent) return res.destroy();
+    next(e);
+  };
+
   // prepare sending to response
-  pipeline.clone().pipe(res);
+  const responseStream = pipeline.clone();
+  responseStream.on('error', onPipelineError);
+  responseStream.pipe(res);
 
   // prepare sending to cache
   if (config.images.cache) {
@@ -121,7 +133,9 @@ function handleSharpStream(req, res, next, pipeline) {
   }
   // flow readStream into the pipeline!
   // this has to be done after of course :D
-  fileManager.streamImage(imageName).pipe(pipeline);
+  const sourceStream = fileManager.streamImage(imageName);
+  sourceStream.on('error', handleFileStreamError(next));
+  sourceStream.pipe(pipeline);
 }
 
 // unlike sharp, no .clone() method
@@ -146,9 +160,46 @@ const handleGifStream = (req, res, next, gifProcessor) => {
     .catch(onWriteResizeError(path));
 };
 
-const streamImageToResponse = (req, res, next, imageName) => {
-  const imageStream = fileManager.streamImage(imageName);
-  const contentType = mime.lookup(imageName);
+const isImageContentType = (contentType) =>
+  typeof contentType === 'string' && contentType.startsWith('image/');
+
+// A gallery filename is not a reliable source of truth for the content type:
+// uploads keep whatever extension they came in with (we have `.bin` and
+// `.false` in production), so `mime.lookup()` answers `application/octet-stream`
+// for what is actually a PNG. The browser then refuses to paint the response in
+// an `<img>`, the editor re-requests the same thumbnail on every re-render, and
+// a single open tab becomes thousands of requests per minute.
+// So when the extension doesn't already name an image type, ask the bytes.
+const resolveContentType = async (imageName) => {
+  const guessedContentType = mime.lookup(imageName);
+  if (isImageContentType(guessedContentType)) return guessedContentType;
+
+  const probeStream = fileManager.streamImage(imageName);
+  try {
+    const { mime: probedContentType } = await probe(probeStream);
+    return isImageContentType(probedContentType)
+      ? probedContentType
+      : guessedContentType;
+  } catch (e) {
+    // unreadable, or genuinely not an image: keep the extension guess
+    return guessedContentType;
+  } finally {
+    // we only needed the header, same abort dance as checkSizes
+    probeStream.destroy();
+  }
+};
+
+const streamImageToResponse = async (req, res, next, imageName) => {
+  let contentType;
+  let imageStream;
+  // this function is fire-and-forget for its callers: an async throw would
+  // become an unhandled rejection instead of reaching the error handler
+  try {
+    contentType = await resolveContentType(imageName);
+    imageStream = fileManager.streamImage(imageName);
+  } catch (e) {
+    return handleFileStreamError(next)(e);
+  }
   imageStream.on('error', handleFileStreamError(next));
   // We have to end stream manually on res stream error (can happen if user close connection before end)
   // If not done, we will have a memory leak
@@ -156,10 +207,6 @@ const streamImageToResponse = (req, res, next, imageName) => {
   // https://groups.google.com/forum/#!topic/nodejs/A8wbaaPmmBQ
   imageStream.once('readable', () => {
     addCacheControl(res);
-    // try to guess content-type from filename
-    // we should do a better thing like a fs-stat
-    // http://stackoverflow.com/questions/13485933/createreadstream-send-file-http#answer-13486341
-    // but we want the response to be as quick as possible
     if (contentType) res.set('Content-Type', contentType);
 
     imageStream
@@ -225,6 +272,15 @@ function checkSizes(req, res, next) {
     .catch(handleFileStreamError(next));
 }
 
+// sharp has no SVG encoder: a vector input always comes out raster. Announce
+// PNG explicitly, otherwise checkSizes has already set `image/svg+xml` on a PNG
+// payload — the browser drops the image and the editor starts retrying.
+const rasterizeVector = (pipeline, imageDatas, res) => {
+  if (imageDatas.type !== 'svg') return pipeline;
+  res.set('Content-Type', 'image/png');
+  return pipeline.png();
+};
+
 /// ///
 // IMAGE GENERATION
 /// ///
@@ -248,7 +304,11 @@ function resize(req, res, next) {
 
   // Sharp can't handle animated gif
   if (imageDatas.type !== 'gif') {
-    const pipeline = sharp().resize(width, height);
+    const pipeline = rasterizeVector(
+      sharp().resize(width, height),
+      imageDatas,
+      res
+    );
     return handleSharpStream(req, res, next, pipeline);
   }
 
@@ -281,7 +341,11 @@ function cover(req, res, next) {
   if (imageDatas.type !== 'gif') {
     // if this method is called we want to resize the image to 2 times the container
     const resizedHeight = height ? height * 2 : null;
-    const pipeline = sharp().resize(width * 2, resizedHeight);
+    const pipeline = rasterizeVector(
+      sharp().resize(width * 2, resizedHeight),
+      imageDatas,
+      res
+    );
     return handleSharpStream(req, res, next, pipeline);
   }
 

--- a/packages/server/image/image.routes.js
+++ b/packages/server/image/image.routes.js
@@ -38,4 +38,17 @@ router.use((req, res, next) => {
   next(new createError.NotImplemented());
 });
 
+// An <img> that receives an uncacheable error is re-requested on every
+// re-render of the editor: that is how a single tab produced 37 req/s of 300 KB
+// responses in production. Let the browser remember the failure for a minute so
+// a broken image can never turn into a flood again.
+const ERROR_CACHE_SECONDS = 60;
+
+router.use((err, req, res, next) => {
+  if (!res.headersSent) {
+    res.set('Cache-Control', `public, max-age=${ERROR_CACHE_SECONDS}`);
+  }
+  next(err);
+});
+
 module.exports = router;

--- a/tests/server/image/image.controller.test.js
+++ b/tests/server/image/image.controller.test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const stream = require('stream');
+
+// The native sharp binary is not installed for every dev platform, and these
+// tests only need the pipeline's shape, not real pixels.
+jest.mock('sharp', () => {
+  const { PassThrough } = require('stream');
+  const makePipeline = () => {
+    const pipeline = new PassThrough();
+    pipeline.resize = jest.fn(() => pipeline);
+    pipeline.png = jest.fn(() => pipeline);
+    pipeline.clone = jest.fn(() => new PassThrough());
+    return pipeline;
+  };
+  return jest.fn(() => makePipeline());
+});
+
+jest.mock('probe-image-size', () => {
+  const probe = jest.fn();
+  probe.sync = jest.fn();
+  return probe;
+});
+jest.mock('../../../packages/server/common/file-manage.service.js', () => ({
+  streamImage: jest.fn(),
+  writeStreamFromStream: jest.fn().mockResolvedValue(undefined),
+  streamImageFromPreviews: jest.fn(),
+}));
+jest.mock('../../../packages/server/common/models.common.js', () => {
+  // used both as a model (findOne) and as a constructor (cache bookkeeping)
+  const CacheImages = jest.fn(() => ({
+    save: jest.fn().mockResolvedValue(undefined),
+  }));
+  CacheImages.findOne = jest.fn();
+  return { CacheImages, Galleries: { findOne: jest.fn() } };
+});
+jest.mock('../../../packages/server/mailing/mailing.service.js', () => ({
+  findOneForUser: jest.fn(),
+}));
+jest.mock('../../../packages/server/image/image.service.js', () => ({
+  createGallery: jest.fn(),
+  createFromUrl: jest.fn(),
+}));
+
+const sharp = require('sharp');
+const probe = require('probe-image-size');
+const fileManager = require('../../../packages/server/common/file-manage.service.js');
+const images = require('../../../packages/server/image/image.controller.js');
+
+const PNG_BYTES = Buffer.from('\x89PNG\r\n\x1a\n-not-a-real-png', 'binary');
+
+function sourceStream(bytes = PNG_BYTES) {
+  const readable = new stream.PassThrough();
+  readable.end(bytes);
+  return readable;
+}
+
+function fakeResponse() {
+  const res = new stream.PassThrough();
+  res.set = jest.fn();
+  res.headersSent = false;
+  return res;
+}
+
+// Waits for the response to be fully written: streamImageToResponse is async
+// (it may probe the payload first), so the assertions can't run synchronously.
+function whenFinished(res) {
+  return new Promise((resolve) => res.on('end', resolve));
+}
+
+describe('image.controller — read()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fileManager.streamImage.mockImplementation(() => sourceStream());
+  });
+
+  it('serves the sniffed type when the extension is not an image one', async () => {
+    // production has gallery files named `.bin` and `.false` that are PNGs
+    probe.mockResolvedValue({ mime: 'image/png', type: 'png' });
+    const res = fakeResponse();
+
+    images.read({ params: { imageName: 'a-b.bin' } }, res, jest.fn());
+    res.resume();
+    await whenFinished(res);
+
+    expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(res.set).not.toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream'
+    );
+  });
+
+  it('trusts an image extension without re-reading the file', async () => {
+    const res = fakeResponse();
+
+    images.read({ params: { imageName: 'a-b.png' } }, res, jest.fn());
+    res.resume();
+    await whenFinished(res);
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(fileManager.streamImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the extension guess when the bytes are not an image', async () => {
+    probe.mockRejectedValue(new Error('unrecognized format'));
+    const res = fakeResponse();
+
+    images.read({ params: { imageName: 'a-b.bin' } }, res, jest.fn());
+    res.resume();
+    await whenFinished(res);
+
+    expect(res.set).toHaveBeenCalledWith(
+      'Content-Type',
+      'application/octet-stream'
+    );
+  });
+});
+
+describe('image.controller — cover()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fileManager.streamImage.mockImplementation(() => sourceStream());
+  });
+
+  it('rasterizes an SVG source and announces PNG', () => {
+    // sharp has no SVG encoder: checkSizes announced `image/svg+xml` from the
+    // source, but the payload is a PNG. Saying so is what stops the browser
+    // from dropping the image and retrying forever.
+    const res = fakeResponse();
+    const req = {
+      path: '/cover/330xnull/a-b.svg',
+      params: { sizes: '330xnull', imageName: 'a-b.svg' },
+      imageDatas: { type: 'svg', mime: 'image/svg+xml', width: 660 },
+    };
+
+    images.cover(req, res, jest.fn());
+
+    const pipeline = sharp.mock.results[0].value;
+    expect(pipeline.png).toHaveBeenCalled();
+    expect(res.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+  });
+
+  it('leaves a raster source untouched', () => {
+    const res = fakeResponse();
+    const req = {
+      path: '/cover/176xnull/a-b.bin',
+      params: { sizes: '176xnull', imageName: 'a-b.bin' },
+      imageDatas: { type: 'png', mime: 'image/png', width: 700 },
+    };
+
+    images.cover(req, res, jest.fn());
+
+    const pipeline = sharp.mock.results[0].value;
+    expect(pipeline.png).not.toHaveBeenCalled();
+    expect(res.set).not.toHaveBeenCalledWith('Content-Type', 'image/png');
+  });
+});


### PR DESCRIPTION
## Contexte

Un onglet de l'éditeur laissé ouvert sur le mailing `6a684fc6b6c2a3150823268e` (Vorwerk) a produit **37 req/s de réponses de 305 Ko, soit 55,7 Go de bande sortante en 29 minutes** sur la prod. Ce n'était pas une attaque : un seul navigateur légitime, en boucle sur 4 URLs de vignettes.

Contenu le soir même par un contournement en base (entrées `cacheimages` pointant sur un placeholder) : 1 920 Mo/min → 3,7 Mo/min. Cette PR corrige la cause pour que le scénario devienne impossible.

## Les deux défauts de typage

**1. Le `Content-Type` était deviné depuis le nom de fichier.** Les uploads conservent l'extension avec laquelle ils arrivent — on a des `.bin` et des `.false` en prod — donc `mime.lookup()` répondait `application/octet-stream` pour ce qui est un PNG. On sonde désormais les octets (`probe-image-size`, déjà une dépendance) **uniquement quand l'extension ne nomme pas déjà un type image** : `.png`, `.jpeg`, `.gif` gardent exactement le comportement précédent, sans lecture supplémentaire.

**2. Une source SVG était annoncée `image/svg+xml` alors que le corps est raster.** sharp n'a pas d'encodeur SVG : une entrée vectorielle ressort forcément en PNG. On force `.png()` et on l'annonce. Ça n'arrivait que quand le SVG déclare plus du double de la largeur de son emplacement, ce qui explique pourquoi les SVG habituels (logos, pictos) passaient.

## Deux durcissements

**Le pipeline sharp n'avait aucun handler d'erreur.** Un échec laissait un `200` à moitié écrit — le pire des cas, parce qu'un 200 tronqué n'est pas mis en cache et est donc redemandé indéfiniment. L'erreur remonte maintenant proprement, et le stream source a aussi son handler.

**Les erreurs du routeur images deviennent cachables 60 s.** C'est le garde-fou générique, et la partie à ne pas retirer à la relecture : il découple « une image est cassée » de « le serveur se fait marteler ». Même avec une boucle de rendu intacte côté client, 8 req/s deviennent 1 req/min.

## Vérification avant / après

Routeur images monté seul, fixtures locales (PNG renommé `.bin`, SVG de 2000 px, SVG de 100 px), comparaison `master` vs cette branche :

| cas | sans le patch | avec le patch |
|---|---|---|
| PNG réel, cover 176 | `image/png` | `image/png` — identique |
| PNG nommé `.bin`, cover redimensionné | `image/png` | `image/png` — identique |
| **PNG nommé `.bin`, servi sans redimensionnement** | **`application/octet-stream`** | **`image/png`** |
| **gros SVG, cover 330** | **`image/svg+xml` sur des octets PNG** | **`image/png`** |
| petit SVG, cover 330 | `image/svg+xml` | `image/svg+xml` — identique |
| fichier inexistant | 404 sans `Cache-Control` | 404 `max-age=60` |
| placeholder | `image/png`, 2 091 o | identique |

Les deux lignes en gras sont les symptômes de prod. Les quatre autres sont inchangées au bit près.

## Tests

5 nouveaux tests dans `tests/server/image/image.controller.test.js` : extension menteuse, extension valide (vérifie qu'aucune lecture supplémentaire n'a lieu), octets non-image, rasterisation SVG, source raster laissée intacte. Suite complète : **550 tests / 45 suites, tout vert**.

sharp est mocké : son binaire natif ne se charge pas sous le système de modules de Jest. Il fonctionne normalement en `node` et en `yarn dev`.

## Hors périmètre, à traiter séparément

- Validation à l'import : refuser ce qui n'est pas une image, normaliser l'extension d'après les octets. C'est la vraie prévention.
- La boucle de rendu de l'éditeur : le `setAttribute('src')` inconditionnel du binding `wysiwygSrc` réévalue l'URL en continu. Le patch rend le serveur robuste, il ne supprime pas la boucle.
- Nettoyage des galeries déjà touchées (6 mailings repérés porteurs de fichiers `.false`).
- `.env` : `lepatron_images__cache="false"` est une chaîne, donc truthy — le cache image ne peut pas être désactivé par variable d'environnement.
- `emailProcessorBackend: "https://builder.badsender.comundefined"` vu dans la console de l'éditeur.

## Après merge

Retirer les 4 entrées `cacheimages` du contournement **après** avoir remplacé les visuels cassés, et **avant** tout export : l'export ZIP/FTP refait des requêtes HTTP sur ces URLs, il embarquerait le placeholder gris dans l'email livré.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
